### PR TITLE
Add CRM adapter framework supporting VAST platforms

### DIFF
--- a/CRMAdapter/CommonConfig/FieldMap.cs
+++ b/CRMAdapter/CommonConfig/FieldMap.cs
@@ -1,0 +1,156 @@
+/*
+ * File: FieldMap.cs
+ * Role: Loads and exposes backend schema mappings used by adapters.
+ * Architectural Purpose: Centralizes schema translation and keeps adapters free from hardcoded SQL metadata.
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace CRMAdapter.CommonConfig
+{
+    /// <summary>
+    /// Represents an immutable mapping between canonical fields and backend schema expressions.
+    /// </summary>
+    public sealed class FieldMap
+    {
+        private readonly IReadOnlyDictionary<string, string> _mappings;
+
+        private FieldMap(string backendName, IReadOnlyDictionary<string, string> mappings)
+        {
+            BackendName = backendName;
+            _mappings = mappings;
+        }
+
+        /// <summary>
+        /// Gets the backend name as declared in the mapping file.
+        /// </summary>
+        public string BackendName { get; }
+
+        /// <summary>
+        /// Loads a field map from a JSON file path.
+        /// </summary>
+        /// <param name="filePath">Absolute or relative path to the mapping file.</param>
+        /// <returns>A <see cref="FieldMap"/> instance.</returns>
+        public static FieldMap LoadFromFile(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            return LoadFromStream(stream);
+        }
+
+        /// <summary>
+        /// Loads a field map from a stream containing JSON mapping data.
+        /// </summary>
+        /// <param name="stream">The JSON stream.</param>
+        /// <returns>A <see cref="FieldMap"/> instance.</returns>
+        public static FieldMap LoadFromStream(Stream stream)
+        {
+            using var document = JsonDocument.Parse(stream);
+            var root = document.RootElement;
+
+            string backendName = root.TryGetProperty("backendName", out var backendElement) &&
+                                 backendElement.ValueKind == JsonValueKind.String
+                ? backendElement.GetString()!
+                : "Unknown";
+
+            var mappingElement = root.TryGetProperty("mappings", out var nested)
+                ? nested
+                : root;
+
+            var mappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            FlattenJson(string.Empty, mappingElement, mappings);
+
+            return new FieldMap(backendName, new ReadOnlyDictionary<string, string>(mappings));
+        }
+
+        /// <summary>
+        /// Retrieves the backend expression for a canonical path.
+        /// </summary>
+        /// <param name="canonicalPath">Canonical property path (e.g. <c>Customer.Name</c>).</param>
+        /// <returns>Backend expression defined in the mapping.</returns>
+        /// <exception cref="MappingConfigurationException">Thrown when the mapping is missing.</exception>
+        public string GetTarget(string canonicalPath)
+        {
+            if (!_mappings.TryGetValue(canonicalPath, out var value))
+            {
+                throw new MappingConfigurationException(
+                    AdapterErrorCodes.MissingMapping,
+                    $"Mapping for '{canonicalPath}' was not found in backend '{BackendName}'.");
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Tries to get the backend expression for a canonical path.
+        /// </summary>
+        /// <param name="canonicalPath">Canonical property path.</param>
+        /// <param name="value">Resolved backend expression.</param>
+        /// <returns><c>true</c> when found; otherwise, <c>false</c>.</returns>
+        public bool TryGetTarget(string canonicalPath, out string value)
+        {
+            return _mappings.TryGetValue(canonicalPath, out value!);
+        }
+
+        /// <summary>
+        /// Retrieves a set of mappings for a canonical entity.
+        /// </summary>
+        /// <param name="entity">Canonical entity name.</param>
+        /// <param name="fields">Canonical fields requested.</param>
+        /// <returns>Dictionary of canonical field to backend expression.</returns>
+        public IReadOnlyDictionary<string, string> GetTargets(string entity, IEnumerable<string> fields)
+        {
+            return fields.ToDictionary(
+                field => field,
+                field => GetTarget($"{entity}.{field}"),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets the configured source (table or view) for the entity when defined.
+        /// </summary>
+        /// <param name="entity">Canonical entity name.</param>
+        /// <returns>The backend source name when defined; otherwise, empty string.</returns>
+        public string GetEntitySource(string entity)
+        {
+            return _mappings.TryGetValue($"{entity}.__source", out var value) ? value : string.Empty;
+        }
+
+        private static void FlattenJson(string prefix, JsonElement element, IDictionary<string, string> mappings)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                throw new MappingConfigurationException(
+                    AdapterErrorCodes.InvalidMapping,
+                    "Mapping files must contain an object of key/value pairs.");
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                var key = string.IsNullOrEmpty(prefix)
+                    ? property.Name
+                    : string.IsNullOrEmpty(property.Name)
+                        ? prefix
+                        : $"{prefix}.{property.Name}";
+
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    FlattenJson(key, property.Value, mappings);
+                }
+                else if (property.Value.ValueKind == JsonValueKind.String)
+                {
+                    mappings[key] = property.Value.GetString()!;
+                }
+                else
+                {
+                    throw new MappingConfigurationException(
+                        AdapterErrorCodes.InvalidMapping,
+                        $"Mapping value for '{key}' must be a string.");
+                }
+            }
+        }
+    }
+}

--- a/CRMAdapter/CommonConfig/MappingValidator.cs
+++ b/CRMAdapter/CommonConfig/MappingValidator.cs
@@ -1,0 +1,91 @@
+/*
+ * File: MappingValidator.cs
+ * Role: Provides validation helpers for schema mapping files and exposes rich configuration exceptions.
+ * Architectural Purpose: Guarantees adapter stability by failing fast when configuration drift is detected.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CRMAdapter.CommonConfig
+{
+    /// <summary>
+    /// Validates mapping configurations for adapter requirements.
+    /// </summary>
+    public static class MappingValidator
+    {
+        /// <summary>
+        /// Ensures the specified canonical keys are present in the <see cref="FieldMap"/>.
+        /// </summary>
+        /// <param name="fieldMap">Mapping instance.</param>
+        /// <param name="canonicalKeys">Canonical keys that must exist.</param>
+        /// <param name="adapterName">Adapter name for diagnostic messages.</param>
+        public static void EnsureMappings(FieldMap fieldMap, IEnumerable<string> canonicalKeys, string adapterName)
+        {
+            if (fieldMap is null)
+            {
+                throw new ArgumentNullException(nameof(fieldMap));
+            }
+
+            if (canonicalKeys is null)
+            {
+                throw new ArgumentNullException(nameof(canonicalKeys));
+            }
+
+            var missingKeys = canonicalKeys
+                .Where(key => !fieldMap.TryGetTarget(key, out _))
+                .ToArray();
+
+            if (missingKeys.Length > 0)
+            {
+                throw new MappingConfigurationException(
+                    AdapterErrorCodes.MissingMapping,
+                    $"Adapter '{adapterName}' detected missing mappings: {string.Join(", ", missingKeys)}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides well-known adapter error codes for telemetry correlation.
+    /// </summary>
+    public static class AdapterErrorCodes
+    {
+        /// <summary>
+        /// Error code for missing mappings.
+        /// </summary>
+        public const string MissingMapping = "CFG001";
+
+        /// <summary>
+        /// Error code for invalid mapping format.
+        /// </summary>
+        public const string InvalidMapping = "CFG002";
+
+        /// <summary>
+        /// Error code for data access failures.
+        /// </summary>
+        public const string DataAccessFailure = "DAL001";
+    }
+
+    /// <summary>
+    /// Exception thrown when mapping configuration issues occur.
+    /// </summary>
+    public sealed class MappingConfigurationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MappingConfigurationException"/> class.
+        /// </summary>
+        /// <param name="errorCode">Machine friendly error code.</param>
+        /// <param name="message">Human readable error message.</param>
+        /// <param name="innerException">Optional inner exception.</param>
+        public MappingConfigurationException(string errorCode, string message, Exception? innerException = null)
+            : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+        }
+
+        /// <summary>
+        /// Gets the error code for logging and telemetry.
+        /// </summary>
+        public string ErrorCode { get; }
+    }
+}

--- a/CRMAdapter/CommonContracts/IAppointmentAdapter.cs
+++ b/CRMAdapter/CommonContracts/IAppointmentAdapter.cs
@@ -1,0 +1,39 @@
+/*
+ * File: IAppointmentAdapter.cs
+ * Role: Declares canonical appointment operations for backend adapters.
+ * Architectural Purpose: Ensures scheduling logic interacts with a unified appointment model.
+ */
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.CommonContracts
+{
+    /// <summary>
+    /// Contract for retrieving canonical appointments from backends.
+    /// </summary>
+    public interface IAppointmentAdapter
+    {
+        /// <summary>
+        /// Gets an appointment by canonical identifier.
+        /// </summary>
+        /// <param name="id">Canonical appointment identifier.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>The appointment when found; otherwise, <c>null</c>.</returns>
+        Task<Appointment?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves appointments scheduled for a specific day.
+        /// </summary>
+        /// <param name="date">Date for which appointments are retrieved.</param>
+        /// <param name="maxResults">Maximum results to return.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Collection of appointments.</returns>
+        Task<IReadOnlyCollection<Appointment>> GetByDateAsync(
+            DateTime date,
+            int maxResults,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/CRMAdapter/CommonContracts/ICustomerAdapter.cs
+++ b/CRMAdapter/CommonContracts/ICustomerAdapter.cs
@@ -1,0 +1,49 @@
+/*
+ * File: ICustomerAdapter.cs
+ * Role: Declares canonical operations for accessing customer data across heterogeneous backends.
+ * Architectural Purpose: Enforces the adapter contract for retrieving canonical customers without leaking schema details.
+ */
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.CommonContracts
+{
+    /// <summary>
+    /// Contract for retrieving canonical customers from a backend system.
+    /// </summary>
+    public interface ICustomerAdapter
+    {
+        /// <summary>
+        /// Gets a customer by the canonical identifier.
+        /// </summary>
+        /// <param name="id">The canonical identifier.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>The customer when found; otherwise, <c>null</c>.</returns>
+        Task<Customer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Searches customers by display name using backend-specific matching semantics.
+        /// </summary>
+        /// <param name="nameQuery">The normalized name fragment.</param>
+        /// <param name="maxResults">Max number of records to return (defaults to framework configuration).</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Collection of matching customers.</returns>
+        Task<IReadOnlyCollection<Customer>> SearchByNameAsync(
+            string nameQuery,
+            int maxResults,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the most recently modified customers for UI dashboards.
+        /// </summary>
+        /// <param name="maxResults">Maximum number of results to return.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Collection of recent customers.</returns>
+        Task<IReadOnlyCollection<Customer>> GetRecentCustomersAsync(
+            int maxResults,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/CRMAdapter/CommonContracts/IInvoiceAdapter.cs
+++ b/CRMAdapter/CommonContracts/IInvoiceAdapter.cs
@@ -1,0 +1,39 @@
+/*
+ * File: IInvoiceAdapter.cs
+ * Role: Establishes canonical operations for invoice retrieval independent of schema specifics.
+ * Architectural Purpose: Enables billing pipelines to operate uniformly across CRM backends.
+ */
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.CommonContracts
+{
+    /// <summary>
+    /// Contract for retrieving canonical invoices from backends.
+    /// </summary>
+    public interface IInvoiceAdapter
+    {
+        /// <summary>
+        /// Gets an invoice by canonical identifier.
+        /// </summary>
+        /// <param name="id">Canonical invoice identifier.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>The invoice when found; otherwise, <c>null</c>.</returns>
+        Task<Invoice?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets invoices for a given customer.
+        /// </summary>
+        /// <param name="customerId">Canonical customer identifier.</param>
+        /// <param name="maxResults">Maximum results to return.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Invoices associated with the customer.</returns>
+        Task<IReadOnlyCollection<Invoice>> GetByCustomerAsync(
+            Guid customerId,
+            int maxResults,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/CRMAdapter/CommonContracts/IVehicleAdapter.cs
+++ b/CRMAdapter/CommonContracts/IVehicleAdapter.cs
@@ -1,0 +1,39 @@
+/*
+ * File: IVehicleAdapter.cs
+ * Role: Defines canonical vehicle retrieval operations shared by backend adapters.
+ * Architectural Purpose: Ensures vehicle data can be accessed independently of underlying schemas.
+ */
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.CommonContracts
+{
+    /// <summary>
+    /// Contract for retrieving canonical vehicles from backends.
+    /// </summary>
+    public interface IVehicleAdapter
+    {
+        /// <summary>
+        /// Gets a vehicle by its canonical identifier.
+        /// </summary>
+        /// <param name="id">The canonical identifier.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>The vehicle when found; otherwise, <c>null</c>.</returns>
+        Task<Vehicle?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves vehicles owned by a specific customer.
+        /// </summary>
+        /// <param name="customerId">Canonical customer identifier.</param>
+        /// <param name="maxResults">Maximum results to return.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Collection of vehicles.</returns>
+        Task<IReadOnlyCollection<Vehicle>> GetByCustomerAsync(
+            Guid customerId,
+            int maxResults,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/CRMAdapter/CommonDomain/Appointment.cs
+++ b/CRMAdapter/CommonDomain/Appointment.cs
@@ -1,0 +1,86 @@
+/*
+ * File: Appointment.cs
+ * Role: Declares the canonical appointment aggregate bridging scheduling data between backend systems.
+ * Architectural Purpose: Provides a normalized scheduling model for customer engagement workflows.
+ */
+using System;
+
+namespace CRMAdapter.CommonDomain
+{
+    /// <summary>
+    /// Represents a canonical service appointment within the CRM domain.
+    /// </summary>
+    public sealed class Appointment
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Appointment"/> class.
+        /// </summary>
+        /// <param name="id">Canonical appointment identifier.</param>
+        /// <param name="customerId">Identifier of the customer associated with the appointment.</param>
+        /// <param name="vehicleId">Identifier of the vehicle serviced during the appointment.</param>
+        /// <param name="scheduledStart">Scheduled start date and time.</param>
+        /// <param name="scheduledEnd">Scheduled end date and time.</param>
+        /// <param name="advisorName">Assigned service advisor.</param>
+        /// <param name="status">Canonical appointment status.</param>
+        /// <param name="location">Appointment location.</param>
+        public Appointment(
+            Guid id,
+            Guid customerId,
+            Guid vehicleId,
+            DateTime scheduledStart,
+            DateTime scheduledEnd,
+            string advisorName,
+            string status,
+            string location)
+        {
+            Id = id;
+            CustomerId = customerId;
+            VehicleId = vehicleId;
+            ScheduledStart = scheduledStart;
+            ScheduledEnd = scheduledEnd;
+            AdvisorName = advisorName ?? throw new ArgumentNullException(nameof(advisorName));
+            Status = status ?? throw new ArgumentNullException(nameof(status));
+            Location = location ?? throw new ArgumentNullException(nameof(location));
+        }
+
+        /// <summary>
+        /// Gets the canonical appointment identifier.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the customer identifier.
+        /// </summary>
+        public Guid CustomerId { get; }
+
+        /// <summary>
+        /// Gets the vehicle identifier.
+        /// </summary>
+        public Guid VehicleId { get; }
+
+        /// <summary>
+        /// Gets the scheduled start time in UTC.
+        /// </summary>
+        public DateTime ScheduledStart { get; }
+
+        /// <summary>
+        /// Gets the scheduled end time in UTC.
+        /// </summary>
+        public DateTime ScheduledEnd { get; }
+
+        /// <summary>
+        /// Gets the assigned service advisor name.
+        /// </summary>
+        public string AdvisorName { get; }
+
+        /// <summary>
+        /// Gets the canonical appointment status.
+        /// </summary>
+        public string Status { get; }
+
+        /// <summary>
+        /// Gets the location for the appointment.
+        /// </summary>
+        public string Location { get; }
+    }
+}

--- a/CRMAdapter/CommonDomain/Customer.cs
+++ b/CRMAdapter/CommonDomain/Customer.cs
@@ -1,0 +1,73 @@
+/*
+ * File: Customer.cs
+ * Role: Defines the canonical CRM customer representation, independent from any backend schema.
+ * Architectural Purpose: Provides an immutable, domain-rich object that acts as the single
+ * source of truth for customer data flowing through the adapter framework.
+ */
+using System;
+using System.Collections.Generic;
+
+namespace CRMAdapter.CommonDomain
+{
+    /// <summary>
+    /// Represents the canonical customer aggregate within the CRM domain, decoupled from backend schemas.
+    /// </summary>
+    public sealed class Customer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Customer"/> class.
+        /// </summary>
+        /// <param name="id">Unique customer identifier in the canonical model.</param>
+        /// <param name="displayName">Normalized display name.</param>
+        /// <param name="email">Primary contact email.</param>
+        /// <param name="primaryPhone">Primary contact phone number.</param>
+        /// <param name="postalAddress">Immutable postal address.</param>
+        /// <param name="vehicles">Vehicles associated to this customer.</param>
+        /// <exception cref="ArgumentNullException">Thrown when any required argument is null.</exception>
+        public Customer(
+            Guid id,
+            string displayName,
+            string email,
+            string primaryPhone,
+            PostalAddress postalAddress,
+            IReadOnlyCollection<VehicleReference> vehicles)
+        {
+            Id = id;
+            DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+            Email = email ?? throw new ArgumentNullException(nameof(email));
+            PrimaryPhone = primaryPhone ?? throw new ArgumentNullException(nameof(primaryPhone));
+            PostalAddress = postalAddress ?? throw new ArgumentNullException(nameof(postalAddress));
+            Vehicles = vehicles ?? throw new ArgumentNullException(nameof(vehicles));
+        }
+
+        /// <summary>
+        /// Gets the canonical identifier of the customer.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the normalized customer name suitable for UI display.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the primary email address.
+        /// </summary>
+        public string Email { get; }
+
+        /// <summary>
+        /// Gets the primary phone number in canonical E.164 format.
+        /// </summary>
+        public string PrimaryPhone { get; }
+
+        /// <summary>
+        /// Gets the immutable postal address for the customer.
+        /// </summary>
+        public PostalAddress PostalAddress { get; }
+
+        /// <summary>
+        /// Gets the vehicles linked to this customer in canonical form.
+        /// </summary>
+        public IReadOnlyCollection<VehicleReference> Vehicles { get; }
+    }
+}

--- a/CRMAdapter/CommonDomain/Invoice.cs
+++ b/CRMAdapter/CommonDomain/Invoice.cs
@@ -1,0 +1,128 @@
+/*
+ * File: Invoice.cs
+ * Role: Provides the canonical representation for service invoices across CRM backends.
+ * Architectural Purpose: Enables consistent billing analytics and reporting by abstracting source schema differences.
+ */
+using System;
+using System.Collections.Generic;
+
+namespace CRMAdapter.CommonDomain
+{
+    /// <summary>
+    /// Canonical invoice aggregate representing customer billing details.
+    /// </summary>
+    public sealed class Invoice
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Invoice"/> class.
+        /// </summary>
+        /// <param name="id">Canonical invoice identifier.</param>
+        /// <param name="customerId">Customer identifier associated with the invoice.</param>
+        /// <param name="vehicleId">Vehicle identifier tied to the invoice.</param>
+        /// <param name="invoiceNumber">Human readable invoice number.</param>
+        /// <param name="invoiceDate">Date the invoice was issued.</param>
+        /// <param name="totalAmount">Total invoice amount.</param>
+        /// <param name="status">Current invoice status.</param>
+        /// <param name="lineItems">Line items billed on the invoice.</param>
+        public Invoice(
+            Guid id,
+            Guid customerId,
+            Guid vehicleId,
+            string invoiceNumber,
+            DateTime invoiceDate,
+            decimal totalAmount,
+            string status,
+            IReadOnlyCollection<InvoiceLine> lineItems)
+        {
+            Id = id;
+            CustomerId = customerId;
+            VehicleId = vehicleId;
+            InvoiceNumber = invoiceNumber ?? throw new ArgumentNullException(nameof(invoiceNumber));
+            InvoiceDate = invoiceDate;
+            TotalAmount = totalAmount;
+            Status = status ?? throw new ArgumentNullException(nameof(status));
+            LineItems = lineItems ?? throw new ArgumentNullException(nameof(lineItems));
+        }
+
+        /// <summary>
+        /// Gets the canonical invoice identifier.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the canonical customer identifier.
+        /// </summary>
+        public Guid CustomerId { get; }
+
+        /// <summary>
+        /// Gets the canonical vehicle identifier.
+        /// </summary>
+        public Guid VehicleId { get; }
+
+        /// <summary>
+        /// Gets the invoice number.
+        /// </summary>
+        public string InvoiceNumber { get; }
+
+        /// <summary>
+        /// Gets the invoice issue date.
+        /// </summary>
+        public DateTime InvoiceDate { get; }
+
+        /// <summary>
+        /// Gets the total invoice amount.
+        /// </summary>
+        public decimal TotalAmount { get; }
+
+        /// <summary>
+        /// Gets the canonical invoice status.
+        /// </summary>
+        public string Status { get; }
+
+        /// <summary>
+        /// Gets the immutable collection of invoice line items.
+        /// </summary>
+        public IReadOnlyCollection<InvoiceLine> LineItems { get; }
+    }
+
+    /// <summary>
+    /// Canonical invoice line item.
+    /// </summary>
+    public sealed class InvoiceLine
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvoiceLine"/> class.
+        /// </summary>
+        /// <param name="description">Line item description.</param>
+        /// <param name="quantity">Line item quantity.</param>
+        /// <param name="unitPrice">Line item unit price.</param>
+        /// <param name="taxAmount">Associated tax amount.</param>
+        public InvoiceLine(string description, decimal quantity, decimal unitPrice, decimal taxAmount)
+        {
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+            Quantity = quantity;
+            UnitPrice = unitPrice;
+            TaxAmount = taxAmount;
+        }
+
+        /// <summary>
+        /// Gets the line item description.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Gets the quantity applied.
+        /// </summary>
+        public decimal Quantity { get; }
+
+        /// <summary>
+        /// Gets the unit price.
+        /// </summary>
+        public decimal UnitPrice { get; }
+
+        /// <summary>
+        /// Gets the tax amount.
+        /// </summary>
+        public decimal TaxAmount { get; }
+    }
+}

--- a/CRMAdapter/CommonDomain/PostalAddress.cs
+++ b/CRMAdapter/CommonDomain/PostalAddress.cs
@@ -1,0 +1,70 @@
+/*
+ * File: PostalAddress.cs
+ * Role: Provides a canonical representation of postal addresses shared by customer and appointment aggregates.
+ * Architectural Purpose: Delivers an immutable value object to prevent schema leakage into the CRM layer.
+ */
+using System;
+
+namespace CRMAdapter.CommonDomain
+{
+    /// <summary>
+    /// Canonical immutable postal address for the CRM domain.
+    /// </summary>
+    public sealed class PostalAddress
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostalAddress"/> class.
+        /// </summary>
+        /// <param name="line1">Primary street line.</param>
+        /// <param name="line2">Secondary street line.</param>
+        /// <param name="city">City component.</param>
+        /// <param name="stateProvince">State or province.</param>
+        /// <param name="postalCode">Postal or ZIP code.</param>
+        /// <param name="countryCode">ISO country code.</param>
+        public PostalAddress(
+            string line1,
+            string line2,
+            string city,
+            string stateProvince,
+            string postalCode,
+            string countryCode)
+        {
+            Line1 = line1 ?? throw new ArgumentNullException(nameof(line1));
+            Line2 = line2;
+            City = city ?? throw new ArgumentNullException(nameof(city));
+            StateProvince = stateProvince ?? throw new ArgumentNullException(nameof(stateProvince));
+            PostalCode = postalCode ?? throw new ArgumentNullException(nameof(postalCode));
+            CountryCode = countryCode ?? throw new ArgumentNullException(nameof(countryCode));
+        }
+
+        /// <summary>
+        /// Gets the primary street line.
+        /// </summary>
+        public string Line1 { get; }
+
+        /// <summary>
+        /// Gets the secondary street line.
+        /// </summary>
+        public string Line2 { get; }
+
+        /// <summary>
+        /// Gets the city value.
+        /// </summary>
+        public string City { get; }
+
+        /// <summary>
+        /// Gets the state or province value.
+        /// </summary>
+        public string StateProvince { get; }
+
+        /// <summary>
+        /// Gets the postal or ZIP code.
+        /// </summary>
+        public string PostalCode { get; }
+
+        /// <summary>
+        /// Gets the ISO country code.
+        /// </summary>
+        public string CountryCode { get; }
+    }
+}

--- a/CRMAdapter/CommonDomain/Vehicle.cs
+++ b/CRMAdapter/CommonDomain/Vehicle.cs
@@ -1,0 +1,106 @@
+/*
+ * File: Vehicle.cs
+ * Role: Encapsulates canonical vehicle information shared across CRM adapters.
+ * Architectural Purpose: Provides an immutable vehicle aggregate supporting cross-backend normalization
+ * and simplifies upstream service integration by abstracting schema divergence.
+ */
+using System;
+
+namespace CRMAdapter.CommonDomain
+{
+    /// <summary>
+    /// Represents a canonical vehicle entity in the CRM domain.
+    /// </summary>
+    public sealed class Vehicle
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vehicle"/> class.
+        /// </summary>
+        /// <param name="id">Canonical vehicle identifier.</param>
+        /// <param name="vin">Vehicle identification number.</param>
+        /// <param name="make">Vehicle manufacturer name.</param>
+        /// <param name="model">Vehicle model designation.</param>
+        /// <param name="modelYear">Four digit model year.</param>
+        /// <param name="odometerReading">Latest known odometer reading in miles.</param>
+        /// <param name="customerId">Identifier linking to the owning customer.</param>
+        public Vehicle(
+            Guid id,
+            string vin,
+            string make,
+            string model,
+            int modelYear,
+            int odometerReading,
+            Guid customerId)
+        {
+            Id = id;
+            Vin = vin ?? throw new ArgumentNullException(nameof(vin));
+            Make = make ?? throw new ArgumentNullException(nameof(make));
+            Model = model ?? throw new ArgumentNullException(nameof(model));
+            ModelYear = modelYear;
+            OdometerReading = odometerReading;
+            CustomerId = customerId;
+        }
+
+        /// <summary>
+        /// Gets the canonical vehicle identifier.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the normalized vehicle identification number.
+        /// </summary>
+        public string Vin { get; }
+
+        /// <summary>
+        /// Gets the vehicle make.
+        /// </summary>
+        public string Make { get; }
+
+        /// <summary>
+        /// Gets the vehicle model.
+        /// </summary>
+        public string Model { get; }
+
+        /// <summary>
+        /// Gets the vehicle model year.
+        /// </summary>
+        public int ModelYear { get; }
+
+        /// <summary>
+        /// Gets the most recent odometer reading in miles.
+        /// </summary>
+        public int OdometerReading { get; }
+
+        /// <summary>
+        /// Gets the owning customer's canonical identifier.
+        /// </summary>
+        public Guid CustomerId { get; }
+    }
+
+    /// <summary>
+    /// Represents a lightweight reference to a vehicle for linking entities together.
+    /// </summary>
+    public sealed class VehicleReference
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VehicleReference"/> class.
+        /// </summary>
+        /// <param name="id">Canonical vehicle identifier.</param>
+        /// <param name="vin">Vehicle VIN to display in lists.</param>
+        public VehicleReference(Guid id, string vin)
+        {
+            Id = id;
+            Vin = vin ?? throw new ArgumentNullException(nameof(vin));
+        }
+
+        /// <summary>
+        /// Gets the canonical vehicle identifier.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the normalized VIN.
+        /// </summary>
+        public string Vin { get; }
+    }
+}

--- a/CRMAdapter/Factory/AdapterFactory.cs
+++ b/CRMAdapter/Factory/AdapterFactory.cs
@@ -1,0 +1,180 @@
+/*
+ * File: AdapterFactory.cs
+ * Role: Centralizes creation of backend-specific adapters based on configuration.
+ * Architectural Purpose: Enables runtime selection of desktop or online adapters while honoring mapping configuration.
+ */
+using System;
+using System.Data.Common;
+using System.IO;
+using CRMAdapter.CommonConfig;
+using CRMAdapter.CommonContracts;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CRMAdapter.Factory
+{
+    /// <summary>
+    /// Creates adapter bundles for a selected backend.
+    /// </summary>
+    public static class AdapterFactory
+    {
+        private const string DesktopKey = "VAST_DESKTOP";
+        private const string OnlineKey = "VAST_ONLINE";
+
+        /// <summary>
+        /// Resolves adapter implementations based on environment variables.
+        /// </summary>
+        /// <param name="connectionFactory">Factory used to create database connections.</param>
+        /// <returns>An adapter bundle for the configured backend.</returns>
+        public static AdapterBundle CreateFromEnvironment(Func<DbConnection> connectionFactory)
+        {
+            var backend = Environment.GetEnvironmentVariable("CRM_BACKEND") ?? DesktopKey;
+            var mappingOverride = Environment.GetEnvironmentVariable("CRM_MAPPING_PATH");
+            return Create(backend, connectionFactory, mappingOverride);
+        }
+
+        /// <summary>
+        /// Creates adapter implementations for the specified backend.
+        /// </summary>
+        /// <param name="backend">Backend key (e.g. VAST_DESKTOP or VAST_ONLINE).</param>
+        /// <param name="connectionFactory">Factory used to create database connections.</param>
+        /// <param name="mappingPath">Optional explicit mapping file path.</param>
+        /// <returns>An adapter bundle.</returns>
+        public static AdapterBundle Create(string backend, Func<DbConnection> connectionFactory, string? mappingPath = null)
+        {
+            if (connectionFactory is null)
+            {
+                throw new ArgumentNullException(nameof(connectionFactory));
+            }
+
+            var normalizedBackend = (backend ?? DesktopKey).ToUpperInvariant();
+            var mappingFile = ResolveMappingPath(normalizedBackend, mappingPath);
+            var fieldMap = FieldMap.LoadFromFile(mappingFile);
+
+            return normalizedBackend switch
+            {
+                DesktopKey => CreateVastDesktopBundle(connectionFactory, fieldMap),
+                OnlineKey => CreateVastOnlineBundle(connectionFactory, fieldMap),
+                _ => throw new NotSupportedException($"Backend '{backend}' is not supported."),
+            };
+        }
+
+        /// <summary>
+        /// Registers Vast Online adapters for dependency injection in a Blazor Server app.
+        /// </summary>
+        /// <param name="services">Service collection.</param>
+        /// <param name="mappingPath">Path to the Vast Online mapping file.</param>
+        /// <param name="connectionFactory">Factory that creates <see cref="DbConnection"/> instances per scope.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddVastOnlineAdapters(
+            this IServiceCollection services,
+            string mappingPath,
+            Func<IServiceProvider, DbConnection> connectionFactory)
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddSingleton(FieldMap.LoadFromFile(mappingPath));
+            services.AddScoped<ICustomerAdapter>(provider =>
+                new VastOnline.Adapter.CustomerAdapter(connectionFactory(provider), provider.GetRequiredService<FieldMap>()));
+            services.AddScoped<IVehicleAdapter>(provider =>
+                new VastOnline.Adapter.VehicleAdapter(connectionFactory(provider), provider.GetRequiredService<FieldMap>()));
+            services.AddScoped<IInvoiceAdapter>(provider =>
+                new VastOnline.Adapter.InvoiceAdapter(connectionFactory(provider), provider.GetRequiredService<FieldMap>()));
+            services.AddScoped<IAppointmentAdapter>(provider =>
+                new VastOnline.Adapter.AppointmentAdapter(connectionFactory(provider), provider.GetRequiredService<FieldMap>()));
+
+            return services;
+        }
+
+        /// <summary>
+        /// Creates a bundle for VAST Desktop consumption (e.g., VB.NET console or COM wrapper).
+        /// </summary>
+        /// <param name="connectionFactory">Factory used to create database connections.</param>
+        /// <param name="mappingPath">Mapping file path.</param>
+        /// <returns>An adapter bundle.</returns>
+        public static AdapterBundle CreateVastDesktop(Func<DbConnection> connectionFactory, string mappingPath)
+        {
+            var fieldMap = FieldMap.LoadFromFile(mappingPath);
+            return CreateVastDesktopBundle(connectionFactory, fieldMap);
+        }
+
+        private static AdapterBundle CreateVastDesktopBundle(Func<DbConnection> connectionFactory, FieldMap fieldMap)
+        {
+            return new AdapterBundle(
+                new Vast.Adapter.CustomerAdapter(connectionFactory(), fieldMap),
+                new Vast.Adapter.VehicleAdapter(connectionFactory(), fieldMap),
+                new Vast.Adapter.InvoiceAdapter(connectionFactory(), fieldMap),
+                new Vast.Adapter.AppointmentAdapter(connectionFactory(), fieldMap));
+        }
+
+        private static AdapterBundle CreateVastOnlineBundle(Func<DbConnection> connectionFactory, FieldMap fieldMap)
+        {
+            return new AdapterBundle(
+                new VastOnline.Adapter.CustomerAdapter(connectionFactory(), fieldMap),
+                new VastOnline.Adapter.VehicleAdapter(connectionFactory(), fieldMap),
+                new VastOnline.Adapter.InvoiceAdapter(connectionFactory(), fieldMap),
+                new VastOnline.Adapter.AppointmentAdapter(connectionFactory(), fieldMap));
+        }
+
+        private static string ResolveMappingPath(string backend, string? mappingPath)
+        {
+            if (!string.IsNullOrWhiteSpace(mappingPath))
+            {
+                return mappingPath!;
+            }
+
+            var baseDirectory = AppContext.BaseDirectory;
+            var relativePath = backend switch
+            {
+                DesktopKey => Path.Combine(baseDirectory, "CRMAdapter", "Vast", "Mapping", "vast-desktop.json"),
+                OnlineKey => Path.Combine(baseDirectory, "CRMAdapter", "VastOnline", "Mapping", "vast-online.json"),
+                _ => throw new NotSupportedException($"Backend '{backend}' is not supported."),
+            };
+
+            return relativePath;
+        }
+    }
+
+    /// <summary>
+    /// Represents an immutable bundle of adapters for a specific backend.
+    /// </summary>
+    public sealed class AdapterBundle
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdapterBundle"/> class.
+        /// </summary>
+        public AdapterBundle(
+            ICustomerAdapter customerAdapter,
+            IVehicleAdapter vehicleAdapter,
+            IInvoiceAdapter invoiceAdapter,
+            IAppointmentAdapter appointmentAdapter)
+        {
+            CustomerAdapter = customerAdapter ?? throw new ArgumentNullException(nameof(customerAdapter));
+            VehicleAdapter = vehicleAdapter ?? throw new ArgumentNullException(nameof(vehicleAdapter));
+            InvoiceAdapter = invoiceAdapter ?? throw new ArgumentNullException(nameof(invoiceAdapter));
+            AppointmentAdapter = appointmentAdapter ?? throw new ArgumentNullException(nameof(appointmentAdapter));
+        }
+
+        /// <summary>
+        /// Gets the customer adapter.
+        /// </summary>
+        public ICustomerAdapter CustomerAdapter { get; }
+
+        /// <summary>
+        /// Gets the vehicle adapter.
+        /// </summary>
+        public IVehicleAdapter VehicleAdapter { get; }
+
+        /// <summary>
+        /// Gets the invoice adapter.
+        /// </summary>
+        public IInvoiceAdapter InvoiceAdapter { get; }
+
+        /// <summary>
+        /// Gets the appointment adapter.
+        /// </summary>
+        public IAppointmentAdapter AppointmentAdapter { get; }
+    }
+}

--- a/CRMAdapter/Vast/Adapter/AppointmentAdapter.vb
+++ b/CRMAdapter/Vast/Adapter/AppointmentAdapter.vb
@@ -1,0 +1,126 @@
+'-----------------------------------------------------------------------
+' File: AppointmentAdapter.vb
+' Role: Implements canonical appointment access for the VAST Desktop backend.
+' Architectural Purpose: Normalizes service scheduling data into the CRM canonical appointment aggregate.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Collections.Generic
+Imports System.Collections.ObjectModel
+Imports System.Data
+Imports System.Data.Common
+Imports System.Linq
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports CRMAdapter.CommonConfig
+Imports CRMAdapter.CommonContracts
+Imports CRMAdapter.CommonDomain
+
+Namespace CRMAdapter.Vast.Adapter
+    ''' <summary>
+    ''' Legacy VAST Desktop implementation of the <see cref="IAppointmentAdapter"/> contract.
+    ''' </summary>
+    Public NotInheritable Class AppointmentAdapter
+        Inherits SqlAdapterBase
+        Implements IAppointmentAdapter
+
+        Private Const DefaultListLimit As Integer = 100
+
+        Private Shared ReadOnly RequiredAppointmentKeys As String() = {
+            "Appointment.__source",
+            "Appointment.Id",
+            "Appointment.CustomerId",
+            "Appointment.VehicleId",
+            "Appointment.Start",
+            "Appointment.End",
+            "Appointment.Advisor",
+            "Appointment.Status",
+            "Appointment.Location"
+        }
+
+        Private Shared ReadOnly AppointmentProjectionFields As String() = {
+            "Id",
+            "CustomerId",
+            "VehicleId",
+            "Start",
+            "End",
+            "Advisor",
+            "Status",
+            "Location"
+        }
+
+        Private ReadOnly _defaultListLimit As Integer
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="AppointmentAdapter"/> class.
+        ''' </summary>
+        Public Sub New(connection As DbConnection, fieldMap As FieldMap, Optional defaultListLimit As Integer = DefaultListLimit)
+            MyBase.New(connection, fieldMap)
+            _defaultListLimit = defaultListLimit
+            MappingValidator.EnsureMappings(fieldMap, RequiredAppointmentKeys, NameOf(AppointmentAdapter))
+        End Sub
+
+        ''' <inheritdoc />
+        Public Async Function GetByIdAsync(id As Guid, Optional cancellationToken As CancellationToken = Nothing) As Task(Of Appointment) Implements IAppointmentAdapter.GetByIdAsync
+            Dim fieldMap = Me.FieldMap.GetTargets("Appointment", AppointmentProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Appointment")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap("Id")} = @id"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@id", id)
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    If Not Await reader.ReadAsync(cancellationToken).ConfigureAwait(False) Then
+                        Return Nothing
+                    End If
+
+                    Return ReadAppointment(reader)
+                End Using
+            End Using
+        End Function
+
+        ''' <inheritdoc />
+        Public Async Function GetByDateAsync([date] As DateTime, maxResults As Integer, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IReadOnlyCollection(Of Appointment)) Implements IAppointmentAdapter.GetByDateAsync
+            Dim limit = Math.Min(_defaultListLimit, If(maxResults > 0, maxResults, _defaultListLimit))
+            Dim fieldMap = Me.FieldMap.GetTargets("Appointment", AppointmentProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Appointment")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim startField = fieldMap("Start")
+            Dim startOfDay = [date].Date
+            Dim endOfDay = startOfDay.AddDays(1)
+            Dim commandText = $"SELECT TOP (@limit) {selectClause} FROM {source} WHERE {startField} >= @start AND {startField} < @end ORDER BY {startField}"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@limit", limit, DbType.Int32)
+                AddParameter(command, "@start", startOfDay, DbType.DateTime2)
+                AddParameter(command, "@end", endOfDay, DbType.DateTime2)
+                Dim appointments As New List(Of Appointment)()
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                        appointments.Add(ReadAppointment(reader))
+                    End While
+                End Using
+
+                Return New ReadOnlyCollection(Of Appointment)(appointments)
+            End Using
+        End Function
+
+        Private Shared Function ReadAppointment(reader As DbDataReader) As Appointment
+            Return New Appointment(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")),
+                reader.GetGuid(reader.GetOrdinal("VehicleId")),
+                reader.GetDateTime(reader.GetOrdinal("Start")),
+                reader.GetDateTime(reader.GetOrdinal("End")),
+                reader.GetString(reader.GetOrdinal("Advisor")),
+                reader.GetString(reader.GetOrdinal("Status")),
+                reader.GetString(reader.GetOrdinal("Location")))
+        End Function
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Adapter/CustomerAdapter.vb
+++ b/CRMAdapter/Vast/Adapter/CustomerAdapter.vb
@@ -1,0 +1,262 @@
+'-----------------------------------------------------------------------
+' File: CustomerAdapter.vb
+' Role: Implements the canonical customer adapter for the VAST Desktop backend.
+' Architectural Purpose: Normalizes legacy SQL Server data to the canonical CRM customer aggregate.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Collections.Generic
+Imports System.Collections.ObjectModel
+Imports System.Data
+Imports System.Data.Common
+Imports System.Linq
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports CRMAdapter.CommonConfig
+Imports CRMAdapter.CommonContracts
+Imports CRMAdapter.CommonDomain
+
+Namespace CRMAdapter.Vast.Adapter
+    ''' <summary>
+    ''' Legacy VAST Desktop implementation of the <see cref="ICustomerAdapter"/> contract.
+    ''' </summary>
+    Public NotInheritable Class CustomerAdapter
+        Inherits SqlAdapterBase
+        Implements ICustomerAdapter
+
+        Private Const DefaultSearchLimit As Integer = 50
+        Private Const DefaultListLimit As Integer = 100
+
+        Private Shared ReadOnly RequiredCustomerKeys As String() = {
+            "Customer.__source",
+            "Customer.Id",
+            "Customer.Name",
+            "Customer.Email",
+            "Customer.Phone",
+            "Customer.AddressLine1",
+            "Customer.AddressLine2",
+            "Customer.City",
+            "Customer.State",
+            "Customer.PostalCode",
+            "Customer.Country",
+            "Customer.ModifiedOn"
+        }
+
+        Private Shared ReadOnly RequiredVehicleReferenceKeys As String() = {
+            "Vehicle.__source",
+            "Vehicle.Id",
+            "Vehicle.Vin",
+            "Vehicle.CustomerId"
+        }
+
+        Private Shared ReadOnly CustomerProjectionFields As String() = {
+            "Id",
+            "Name",
+            "Email",
+            "Phone",
+            "AddressLine1",
+            "AddressLine2",
+            "City",
+            "State",
+            "PostalCode",
+            "Country"
+        }
+
+        Private ReadOnly _defaultSearchLimit As Integer
+        Private ReadOnly _defaultListLimit As Integer
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="CustomerAdapter"/> class.
+        ''' </summary>
+        Public Sub New(connection As DbConnection, fieldMap As FieldMap, Optional defaultSearchLimit As Integer = DefaultSearchLimit, Optional defaultListLimit As Integer = DefaultListLimit)
+            MyBase.New(connection, fieldMap)
+            _defaultSearchLimit = defaultSearchLimit
+            _defaultListLimit = defaultListLimit
+            MappingValidator.EnsureMappings(fieldMap, RequiredCustomerKeys, NameOf(CustomerAdapter))
+            MappingValidator.EnsureMappings(fieldMap, RequiredVehicleReferenceKeys, NameOf(CustomerAdapter))
+        End Sub
+
+        ''' <inheritdoc />
+        Public Async Function GetByIdAsync(id As Guid, Optional cancellationToken As CancellationToken = Nothing) As Task(Of Customer) Implements ICustomerAdapter.GetByIdAsync
+            Dim fieldMap = Me.FieldMap.GetTargets("Customer", CustomerProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Customer")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap("Id")} = @id"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@id", id)
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    If Not Await reader.ReadAsync(cancellationToken).ConfigureAwait(False) Then
+                        Return Nothing
+                    End If
+
+                    Dim snapshot = ReadCustomerSnapshot(reader)
+                    Dim vehicleLookup = Await LoadVehicleReferencesAsync(New Guid() {snapshot.Id}, cancellationToken).ConfigureAwait(False)
+                    Dim vehicles As IReadOnlyCollection(Of VehicleReference) = Nothing
+                    If Not vehicleLookup.TryGetValue(snapshot.Id, vehicles) Then
+                        vehicles = Array.Empty(Of VehicleReference)()
+                    End If
+                    Return snapshot.ToCustomer(vehicles)
+                End Using
+            End Using
+        End Function
+
+        ''' <inheritdoc />
+        Public Async Function SearchByNameAsync(nameQuery As String, maxResults As Integer, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IReadOnlyCollection(Of Customer)) Implements ICustomerAdapter.SearchByNameAsync
+            If String.IsNullOrWhiteSpace(nameQuery) Then
+                Throw New ArgumentException("Name query must be supplied.", NameOf(nameQuery))
+            End If
+
+            Dim limit = Math.Min(_defaultSearchLimit, If(maxResults > 0, maxResults, _defaultSearchLimit))
+            Dim fieldMap = Me.FieldMap.GetTargets("Customer", CustomerProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Customer")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT TOP (@limit) {selectClause} FROM {source} WHERE {fieldMap("Name")} LIKE @name ORDER BY {fieldMap("Name")}"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@limit", limit, DbType.Int32)
+                AddParameter(command, "@name", $"%{nameQuery}%")
+
+                Dim snapshots = Await ReadSnapshotsAsync(command, cancellationToken).ConfigureAwait(False)
+                Dim vehicleLookup = Await LoadVehicleReferencesAsync(snapshots.Select(Function(s) s.Id), cancellationToken).ConfigureAwait(False)
+
+                Dim customers = snapshots.Select(Function(snapshot)
+                                                     Dim vehicles As IReadOnlyCollection(Of VehicleReference) = Nothing
+                                                     If Not vehicleLookup.TryGetValue(snapshot.Id, vehicles) Then
+                                                         vehicles = Array.Empty(Of VehicleReference)()
+                                                     End If
+                                                     Return snapshot.ToCustomer(vehicles)
+                                                 End Function).ToList()
+                Return New ReadOnlyCollection(Of Customer)(customers)
+            End Using
+        End Function
+
+        ''' <inheritdoc />
+        Public Async Function GetRecentCustomersAsync(maxResults As Integer, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IReadOnlyCollection(Of Customer)) Implements ICustomerAdapter.GetRecentCustomersAsync
+            Dim limit = Math.Min(_defaultListLimit, If(maxResults > 0, maxResults, _defaultListLimit))
+            Dim fieldMap = Me.FieldMap.GetTargets("Customer", CustomerProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Customer")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim modifiedOnField = Me.FieldMap.GetTarget("Customer.ModifiedOn")
+            Dim commandText = $"SELECT TOP (@limit) {selectClause} FROM {source} ORDER BY {modifiedOnField} DESC"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@limit", limit, DbType.Int32)
+                Dim snapshots = Await ReadSnapshotsAsync(command, cancellationToken).ConfigureAwait(False)
+                Dim vehicleLookup = Await LoadVehicleReferencesAsync(snapshots.Select(Function(s) s.Id), cancellationToken).ConfigureAwait(False)
+
+                Dim customers = snapshots.Select(Function(snapshot)
+                                                     Dim vehicles As IReadOnlyCollection(Of VehicleReference) = Nothing
+                                                     If Not vehicleLookup.TryGetValue(snapshot.Id, vehicles) Then
+                                                         vehicles = Array.Empty(Of VehicleReference)()
+                                                     End If
+                                                     Return snapshot.ToCustomer(vehicles)
+                                                 End Function).ToList()
+                Return New ReadOnlyCollection(Of Customer)(customers)
+            End Using
+        End Function
+
+        Private Async Function LoadVehicleReferencesAsync(customerIds As IEnumerable(Of Guid), cancellationToken As CancellationToken) As Task(Of IReadOnlyDictionary(Of Guid, IReadOnlyCollection(Of VehicleReference)))
+            Dim idList = customerIds.Distinct().ToList()
+            If idList.Count = 0 Then
+                Return New Dictionary(Of Guid, IReadOnlyCollection(Of VehicleReference))()
+            End If
+
+            Dim fields = Me.FieldMap.GetTargets("Vehicle", New String() {"Id", "Vin", "CustomerId"})
+            Dim source = Me.FieldMap.GetEntitySource("Vehicle")
+            Dim parameterNames = idList.Select(Function(_, index) $"@c{index}").ToArray()
+            Dim selectClause = $"{fields("Id")} AS [VehicleId], {fields("Vin")} AS [Vin], {fields("CustomerId")} AS [CustomerId]"
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fields("CustomerId")} IN ({String.Join(", ", parameterNames)})"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                For i = 0 To idList.Count - 1
+                    AddParameter(command, parameterNames(i), idList(i))
+                Next
+
+                Dim accumulator As New Dictionary(Of Guid, List(Of VehicleReference))()
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                        Dim customerId = reader.GetGuid(reader.GetOrdinal("CustomerId"))
+                        Dim vehicleId = reader.GetGuid(reader.GetOrdinal("VehicleId"))
+                        Dim vin = reader.GetString(reader.GetOrdinal("Vin"))
+
+                        Dim vehicles As List(Of VehicleReference) = Nothing
+                        If Not accumulator.TryGetValue(customerId, vehicles) Then
+                            vehicles = New List(Of VehicleReference)()
+                            accumulator(customerId) = vehicles
+                        End If
+
+                        vehicles.Add(New VehicleReference(vehicleId, vin))
+                    End While
+                End Using
+
+                Return accumulator.ToDictionary(Function(pair) pair.Key, Function(pair) CType(pair.Value.AsReadOnly(), IReadOnlyCollection(Of VehicleReference)))
+            End Using
+        End Function
+
+        Private Shared Async Function ReadSnapshotsAsync(command As DbCommand, cancellationToken As CancellationToken) As Task(Of List(Of CustomerSnapshot))
+            Dim snapshots As New List(Of CustomerSnapshot)()
+            Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+            Using reader
+                While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                    snapshots.Add(ReadCustomerSnapshot(reader))
+                End While
+            End Using
+
+            Return snapshots
+        End Function
+
+        Private Shared Function ReadCustomerSnapshot(reader As DbDataReader) As CustomerSnapshot
+            Return New CustomerSnapshot(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetString(reader.GetOrdinal("Name")),
+                reader.GetString(reader.GetOrdinal("Email")),
+                reader.GetString(reader.GetOrdinal("Phone")),
+                reader.GetString(reader.GetOrdinal("AddressLine1")),
+                If(reader.IsDBNull(reader.GetOrdinal("AddressLine2")), String.Empty, reader.GetString(reader.GetOrdinal("AddressLine2"))),
+                reader.GetString(reader.GetOrdinal("City")),
+                reader.GetString(reader.GetOrdinal("State")),
+                reader.GetString(reader.GetOrdinal("PostalCode")),
+                reader.GetString(reader.GetOrdinal("Country")))
+        End Function
+
+        Private NotInheritable Class CustomerSnapshot
+            Public Sub New(id As Guid, displayName As String, email As String, primaryPhone As String, line1 As String, line2 As String, city As String, state As String, postalCode As String, country As String)
+                Me.Id = id
+                Me.DisplayName = displayName
+                Me.Email = email
+                Me.PrimaryPhone = primaryPhone
+                Me.Line1 = line1
+                Me.Line2 = line2
+                Me.City = city
+                Me.State = state
+                Me.PostalCode = postalCode
+                Me.Country = country
+            End Sub
+
+            Public ReadOnly Property Id As Guid
+            Public ReadOnly Property DisplayName As String
+            Public ReadOnly Property Email As String
+            Public ReadOnly Property PrimaryPhone As String
+            Public ReadOnly Property Line1 As String
+            Public ReadOnly Property Line2 As String
+            Public ReadOnly Property City As String
+            Public ReadOnly Property State As String
+            Public ReadOnly Property PostalCode As String
+            Public ReadOnly Property Country As String
+
+            Public Function ToCustomer(vehicles As IReadOnlyCollection(Of VehicleReference)) As Customer
+                Dim address = New PostalAddress(Line1, Line2, City, State, PostalCode, Country)
+                Return New Customer(Id, DisplayName, Email, PrimaryPhone, address, vehicles)
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Adapter/InvoiceAdapter.vb
+++ b/CRMAdapter/Vast/Adapter/InvoiceAdapter.vb
@@ -1,0 +1,206 @@
+'-----------------------------------------------------------------------
+' File: InvoiceAdapter.vb
+' Role: Implements canonical invoice access for the VAST Desktop backend.
+' Architectural Purpose: Projects legacy billing data into the CRM canonical invoice aggregate including line items.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Collections.Generic
+Imports System.Collections.ObjectModel
+Imports System.Data
+Imports System.Data.Common
+Imports System.Linq
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports CRMAdapter.CommonConfig
+Imports CRMAdapter.CommonContracts
+Imports CRMAdapter.CommonDomain
+
+Namespace CRMAdapter.Vast.Adapter
+    ''' <summary>
+    ''' Legacy VAST Desktop implementation of the <see cref="IInvoiceAdapter"/> contract.
+    ''' </summary>
+    Public NotInheritable Class InvoiceAdapter
+        Inherits SqlAdapterBase
+        Implements IInvoiceAdapter
+
+        Private Const DefaultListLimit As Integer = 100
+
+        Private Shared ReadOnly RequiredInvoiceKeys As String() = {
+            "Invoice.__source",
+            "Invoice.Id",
+            "Invoice.CustomerId",
+            "Invoice.VehicleId",
+            "Invoice.Number",
+            "Invoice.Date",
+            "Invoice.Total",
+            "Invoice.Status"
+        }
+
+        Private Shared ReadOnly RequiredInvoiceLineKeys As String() = {
+            "InvoiceLine.__source",
+            "InvoiceLine.InvoiceId",
+            "InvoiceLine.Description",
+            "InvoiceLine.Quantity",
+            "InvoiceLine.UnitPrice",
+            "InvoiceLine.Tax"
+        }
+
+        Private Shared ReadOnly InvoiceProjectionFields As String() = {
+            "Id",
+            "CustomerId",
+            "VehicleId",
+            "Number",
+            "Date",
+            "Total",
+            "Status"
+        }
+
+        Private ReadOnly _defaultListLimit As Integer
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="InvoiceAdapter"/> class.
+        ''' </summary>
+        Public Sub New(connection As DbConnection, fieldMap As FieldMap, Optional defaultListLimit As Integer = DefaultListLimit)
+            MyBase.New(connection, fieldMap)
+            _defaultListLimit = defaultListLimit
+            MappingValidator.EnsureMappings(fieldMap, RequiredInvoiceKeys, NameOf(InvoiceAdapter))
+            MappingValidator.EnsureMappings(fieldMap, RequiredInvoiceLineKeys, NameOf(InvoiceAdapter))
+        End Sub
+
+        ''' <inheritdoc />
+        Public Async Function GetByIdAsync(id As Guid, Optional cancellationToken As CancellationToken = Nothing) As Task(Of Invoice) Implements IInvoiceAdapter.GetByIdAsync
+            Dim fieldMap = Me.FieldMap.GetTargets("Invoice", InvoiceProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Invoice")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap("Id")} = @id"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@id", id)
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    If Not Await reader.ReadAsync(cancellationToken).ConfigureAwait(False) Then
+                        Return Nothing
+                    End If
+
+                    Dim invoiceRecord = ReadInvoice(reader)
+                    Dim lines = Await LoadInvoiceLinesAsync(New Guid() {invoiceRecord.Id}, cancellationToken).ConfigureAwait(False)
+                    Dim lineItems As IReadOnlyCollection(Of InvoiceLine) = Nothing
+                    If Not lines.TryGetValue(invoiceRecord.Id, lineItems) Then
+                        lineItems = Array.Empty(Of InvoiceLine)()
+                    End If
+
+                    Return New Invoice(invoiceRecord.Id, invoiceRecord.CustomerId, invoiceRecord.VehicleId, invoiceRecord.InvoiceNumber, invoiceRecord.InvoiceDate, invoiceRecord.TotalAmount, invoiceRecord.Status, lineItems)
+                End Using
+            End Using
+        End Function
+
+        ''' <inheritdoc />
+        Public Async Function GetByCustomerAsync(customerId As Guid, maxResults As Integer, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IReadOnlyCollection(Of Invoice)) Implements IInvoiceAdapter.GetByCustomerAsync
+            Dim limit = Math.Min(_defaultListLimit, If(maxResults > 0, maxResults, _defaultListLimit))
+            Dim fieldMap = Me.FieldMap.GetTargets("Invoice", InvoiceProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Invoice")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT TOP (@limit) {selectClause} FROM {source} WHERE {fieldMap("CustomerId")} = @customerId ORDER BY {fieldMap("Date")} DESC"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@limit", limit, DbType.Int32)
+                AddParameter(command, "@customerId", customerId)
+                Dim invoices As New List(Of InvoiceRecord)()
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                        invoices.Add(ReadInvoice(reader))
+                    End While
+                End Using
+
+                Dim lineLookup = Await LoadInvoiceLinesAsync(invoices.Select(Function(i) i.Id), cancellationToken).ConfigureAwait(False)
+                Dim results = invoices.Select(Function(record)
+                                                  Dim lineItems As IReadOnlyCollection(Of InvoiceLine) = Nothing
+                                                  If Not lineLookup.TryGetValue(record.Id, lineItems) Then
+                                                      lineItems = Array.Empty(Of InvoiceLine)()
+                                                  End If
+                                                  Return New Invoice(record.Id, record.CustomerId, record.VehicleId, record.InvoiceNumber, record.InvoiceDate, record.TotalAmount, record.Status, lineItems)
+                                              End Function).ToList()
+                Return New ReadOnlyCollection(Of Invoice)(results)
+            End Using
+        End Function
+
+        Private Async Function LoadInvoiceLinesAsync(invoiceIds As IEnumerable(Of Guid), cancellationToken As CancellationToken) As Task(Of IReadOnlyDictionary(Of Guid, IReadOnlyCollection(Of InvoiceLine)))
+            Dim ids = invoiceIds.Distinct().ToList()
+            If ids.Count = 0 Then
+                Return New Dictionary(Of Guid, IReadOnlyCollection(Of InvoiceLine))()
+            End If
+
+            Dim fields = Me.FieldMap.GetTargets("InvoiceLine", New String() {"InvoiceId", "Description", "Quantity", "UnitPrice", "Tax"})
+            Dim source = Me.FieldMap.GetEntitySource("InvoiceLine")
+            Dim parameterNames = ids.Select(Function(_, index) $"@i{index}").ToArray()
+            Dim selectClause = $"{fields("InvoiceId")} AS [InvoiceId], {fields("Description")} AS [Description], {fields("Quantity")} AS [Quantity], {fields("UnitPrice")} AS [UnitPrice], {fields("Tax")} AS [Tax]"
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fields("InvoiceId")} IN ({String.Join(", ", parameterNames)})"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                For i = 0 To ids.Count - 1
+                    AddParameter(command, parameterNames(i), ids(i))
+                Next
+
+                Dim accumulator As New Dictionary(Of Guid, List(Of InvoiceLine))()
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                        Dim invoiceId = reader.GetGuid(reader.GetOrdinal("InvoiceId"))
+                        Dim description = reader.GetString(reader.GetOrdinal("Description"))
+                        Dim quantity = reader.GetDecimal(reader.GetOrdinal("Quantity"))
+                        Dim unitPrice = reader.GetDecimal(reader.GetOrdinal("UnitPrice"))
+                        Dim tax = reader.GetDecimal(reader.GetOrdinal("Tax"))
+
+                        Dim lines As List(Of InvoiceLine) = Nothing
+                        If Not accumulator.TryGetValue(invoiceId, lines) Then
+                            lines = New List(Of InvoiceLine)()
+                            accumulator(invoiceId) = lines
+                        End If
+
+                        lines.Add(New InvoiceLine(description, quantity, unitPrice, tax))
+                    End While
+                End Using
+
+                Return accumulator.ToDictionary(Function(pair) pair.Key, Function(pair) CType(pair.Value.AsReadOnly(), IReadOnlyCollection(Of InvoiceLine)))
+            End Using
+        End Function
+
+        Private Shared Function ReadInvoice(reader As DbDataReader) As InvoiceRecord
+            Return New InvoiceRecord(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")),
+                reader.GetGuid(reader.GetOrdinal("VehicleId")),
+                reader.GetString(reader.GetOrdinal("Number")),
+                reader.GetDateTime(reader.GetOrdinal("Date")),
+                reader.GetDecimal(reader.GetOrdinal("Total")),
+                reader.GetString(reader.GetOrdinal("Status")))
+        End Function
+
+        Private NotInheritable Class InvoiceRecord
+            Public Sub New(id As Guid, customerId As Guid, vehicleId As Guid, invoiceNumber As String, invoiceDate As DateTime, totalAmount As Decimal, status As String)
+                Me.Id = id
+                Me.CustomerId = customerId
+                Me.VehicleId = vehicleId
+                Me.InvoiceNumber = invoiceNumber
+                Me.InvoiceDate = invoiceDate
+                Me.TotalAmount = totalAmount
+                Me.Status = status
+            End Sub
+
+            Public ReadOnly Property Id As Guid
+            Public ReadOnly Property CustomerId As Guid
+            Public ReadOnly Property VehicleId As Guid
+            Public ReadOnly Property InvoiceNumber As String
+            Public ReadOnly Property InvoiceDate As DateTime
+            Public ReadOnly Property TotalAmount As Decimal
+            Public ReadOnly Property Status As String
+        End Class
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Adapter/SqlAdapterBase.vb
+++ b/CRMAdapter/Vast/Adapter/SqlAdapterBase.vb
@@ -1,0 +1,131 @@
+'-----------------------------------------------------------------------
+' File: SqlAdapterBase.vb
+' Role: Provides shared SQL helper functionality for VAST Desktop adapters.
+' Architectural Purpose: Centralizes async connection management and parameter handling for legacy SQL Server.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Data
+Imports System.Data.Common
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports CRMAdapter.CommonConfig
+
+Namespace CRMAdapter.Vast.Adapter
+    ''' <summary>
+    ''' Base class that unifies SQL helper behavior across VB.NET adapters.
+    ''' </summary>
+    Public MustInherit Class SqlAdapterBase
+        Implements IDisposable
+
+        Private ReadOnly _connectionLock As New SemaphoreSlim(1, 1)
+        Private _disposed As Boolean
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="SqlAdapterBase"/> class.
+        ''' </summary>
+        ''' <param name="connection">Database connection.</param>
+        ''' <param name="fieldMap">Field map configuration.</param>
+        Protected Sub New(connection As DbConnection, fieldMap As FieldMap)
+            If connection Is Nothing Then
+                Throw New ArgumentNullException(NameOf(connection))
+            End If
+
+            If fieldMap Is Nothing Then
+                Throw New ArgumentNullException(NameOf(fieldMap))
+            End If
+
+            Me.Connection = connection
+            Me.FieldMap = fieldMap
+        End Sub
+
+        ''' <summary>
+        ''' Gets the database connection.
+        ''' </summary>
+        Protected ReadOnly Property Connection As DbConnection
+
+        ''' <summary>
+        ''' Gets the field map configuration.
+        ''' </summary>
+        Protected ReadOnly Property FieldMap As FieldMap
+
+        ''' <summary>
+        ''' Creates a command ensuring the connection is open.
+        ''' </summary>
+        Protected Async Function CreateCommandAsync(commandText As String, cancellationToken As CancellationToken) As Task(Of DbCommand)
+            If commandText Is Nothing Then
+                Throw New ArgumentNullException(NameOf(commandText))
+            End If
+
+            Await EnsureConnectionAsync(cancellationToken).ConfigureAwait(False)
+            Dim command = Connection.CreateCommand()
+            command.CommandText = commandText
+            command.CommandType = CommandType.Text
+            Return command
+        End Function
+
+        ''' <summary>
+        ''' Adds a parameter to the provided command.
+        ''' </summary>
+        Protected Shared Sub AddParameter(command As DbCommand, name As String, value As Object, Optional dbType As DbType? = Nothing)
+            If command Is Nothing Then
+                Throw New ArgumentNullException(NameOf(command))
+            End If
+
+            If name Is Nothing Then
+                Throw New ArgumentNullException(NameOf(name))
+            End If
+
+            Dim parameter = command.CreateParameter()
+            parameter.ParameterName = name
+            parameter.Value = If(value, DBNull.Value)
+            If dbType.HasValue Then
+                parameter.DbType = dbType.Value
+            End If
+
+            command.Parameters.Add(parameter)
+        End Sub
+
+
+        ''' <summary>
+        ''' Disposes the adapter and underlying connection.
+        ''' </summary>
+        Public Sub Dispose() Implements IDisposable.Dispose
+            Dispose(True)
+            GC.SuppressFinalize(Me)
+        End Sub
+
+        ''' <summary>
+        ''' Performs the dispose pattern logic.
+        ''' </summary>
+        ''' <param name="disposing">Indicates whether managed resources should be disposed.</param>
+        Protected Overridable Sub Dispose(disposing As Boolean)
+            If _disposed Then
+                Return
+            End If
+
+            If disposing Then
+                Connection.Dispose()
+            End If
+
+            _disposed = True
+        End Sub
+
+        Private Async Function EnsureConnectionAsync(cancellationToken As CancellationToken) As Task
+            If Connection.State = ConnectionState.Open Then
+                Return
+            End If
+
+            Await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(False)
+            Try
+                If Connection.State <> ConnectionState.Open Then
+                    Await Connection.OpenAsync(cancellationToken).ConfigureAwait(False)
+                End If
+            Finally
+                _connectionLock.Release()
+            End Try
+        End Function
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Adapter/VehicleAdapter.vb
+++ b/CRMAdapter/Vast/Adapter/VehicleAdapter.vb
@@ -1,0 +1,119 @@
+'-----------------------------------------------------------------------
+' File: VehicleAdapter.vb
+' Role: Implements canonical vehicle access for the VAST Desktop backend.
+' Architectural Purpose: Maps legacy vehicle data to the canonical CRM vehicle aggregate.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Collections.Generic
+Imports System.Collections.ObjectModel
+Imports System.Data
+Imports System.Data.Common
+Imports System.Linq
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports CRMAdapter.CommonConfig
+Imports CRMAdapter.CommonContracts
+Imports CRMAdapter.CommonDomain
+
+Namespace CRMAdapter.Vast.Adapter
+    ''' <summary>
+    ''' Legacy VAST Desktop implementation of the <see cref="IVehicleAdapter"/> contract.
+    ''' </summary>
+    Public NotInheritable Class VehicleAdapter
+        Inherits SqlAdapterBase
+        Implements IVehicleAdapter
+
+        Private Const DefaultListLimit As Integer = 100
+
+        Private Shared ReadOnly RequiredVehicleKeys As String() = {
+            "Vehicle.__source",
+            "Vehicle.Id",
+            "Vehicle.CustomerId",
+            "Vehicle.Vin",
+            "Vehicle.Make",
+            "Vehicle.Model",
+            "Vehicle.ModelYear",
+            "Vehicle.Odometer"
+        }
+
+        Private Shared ReadOnly VehicleProjectionFields As String() = {
+            "Id",
+            "CustomerId",
+            "Vin",
+            "Make",
+            "Model",
+            "ModelYear",
+            "Odometer"
+        }
+
+        Private ReadOnly _defaultListLimit As Integer
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="VehicleAdapter"/> class.
+        ''' </summary>
+        Public Sub New(connection As DbConnection, fieldMap As FieldMap, Optional defaultListLimit As Integer = DefaultListLimit)
+            MyBase.New(connection, fieldMap)
+            _defaultListLimit = defaultListLimit
+            MappingValidator.EnsureMappings(fieldMap, RequiredVehicleKeys, NameOf(VehicleAdapter))
+        End Sub
+
+        ''' <inheritdoc />
+        Public Async Function GetByIdAsync(id As Guid, Optional cancellationToken As CancellationToken = Nothing) As Task(Of Vehicle) Implements IVehicleAdapter.GetByIdAsync
+            Dim fieldMap = Me.FieldMap.GetTargets("Vehicle", VehicleProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Vehicle")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap("Id")} = @id"
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@id", id)
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    If Not Await reader.ReadAsync(cancellationToken).ConfigureAwait(False) Then
+                        Return Nothing
+                    End If
+
+                    Return ReadVehicle(reader)
+                End Using
+            End Using
+        End Function
+
+        ''' <inheritdoc />
+        Public Async Function GetByCustomerAsync(customerId As Guid, maxResults As Integer, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IReadOnlyCollection(Of Vehicle)) Implements IVehicleAdapter.GetByCustomerAsync
+            Dim limit = Math.Min(_defaultListLimit, If(maxResults > 0, maxResults, _defaultListLimit))
+            Dim fieldMap = Me.FieldMap.GetTargets("Vehicle", VehicleProjectionFields)
+            Dim source = Me.FieldMap.GetEntitySource("Vehicle")
+            Dim selectClause = String.Join(", ", fieldMap.Select(Function(kvp) $"{kvp.Value} AS [{kvp.Key}]"))
+            Dim commandText = $"SELECT TOP (@limit) {selectClause} FROM {source} WHERE {fieldMap("CustomerId")} = @customerId ORDER BY {fieldMap("ModelYear")} DESC, {fieldMap("Make")}, {fieldMap("Model")}" 
+
+            Dim command = Await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(False)
+            Using command
+                AddParameter(command, "@limit", limit, DbType.Int32)
+                AddParameter(command, "@customerId", customerId)
+                Dim vehicles As New List(Of Vehicle)()
+                Dim reader = Await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(False)
+                Using reader
+                    While Await reader.ReadAsync(cancellationToken).ConfigureAwait(False)
+                        vehicles.Add(ReadVehicle(reader))
+                    End While
+                End Using
+
+                Return New ReadOnlyCollection(Of Vehicle)(vehicles)
+            End Using
+        End Function
+
+        Private Shared Function ReadVehicle(reader As DbDataReader) As Vehicle
+            Return New Vehicle(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetString(reader.GetOrdinal("Vin")),
+                reader.GetString(reader.GetOrdinal("Make")),
+                reader.GetString(reader.GetOrdinal("Model")),
+                reader.GetInt32(reader.GetOrdinal("ModelYear")),
+                reader.GetInt32(reader.GetOrdinal("Odometer")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")))
+        End Function
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Interop/ComAdapterWrapper.vb
+++ b/CRMAdapter/Vast/Interop/ComAdapterWrapper.vb
@@ -1,0 +1,102 @@
+'-----------------------------------------------------------------------
+' File: ComAdapterWrapper.vb
+' Role: Exposes COM-friendly methods for VB6 clients to consume canonical CRM data via JSON payloads.
+' Architectural Purpose: Bridges legacy VB6 UIs with the modern adapter framework without schema awareness.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Runtime.InteropServices
+Imports System.Text.Json
+Imports CRMAdapter.CommonContracts
+Imports CRMAdapter.CommonDomain
+
+Namespace CRMAdapter.Vast.Interop
+    ''' <summary>
+    ''' COM visible wrapper exposing JSON-based access to canonical CRM objects.
+    ''' </summary>
+    <ComVisible(True)>
+    <Guid("C6CB1E24-7092-4DC4-9EC6-74D7C53AC1DE")>
+    <ClassInterface(ClassInterfaceType.None)>
+    Public NotInheritable Class ComAdapterWrapper
+        Private Shared ReadOnly JsonOptions As New JsonSerializerOptions With {
+            .PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            .WriteIndented = False
+        }
+
+        Private ReadOnly _customerAdapter As ICustomerAdapter
+        Private ReadOnly _vehicleAdapter As IVehicleAdapter
+        Private ReadOnly _invoiceAdapter As IInvoiceAdapter
+        Private ReadOnly _appointmentAdapter As IAppointmentAdapter
+
+        ''' <summary>
+        ''' Initializes a new instance of the <see cref="ComAdapterWrapper"/> class.
+        ''' </summary>
+        Public Sub New(customerAdapter As ICustomerAdapter, vehicleAdapter As IVehicleAdapter, invoiceAdapter As IInvoiceAdapter, appointmentAdapter As IAppointmentAdapter)
+            _customerAdapter = customerAdapter
+            _vehicleAdapter = vehicleAdapter
+            _invoiceAdapter = invoiceAdapter
+            _appointmentAdapter = appointmentAdapter
+        End Sub
+
+        ''' <summary>
+        ''' Retrieves a customer and vehicles serialized as JSON for VB6 consumption.
+        ''' </summary>
+        Public Function GetCustomerByIdJson(id As String) As String
+            Try
+                Dim customerId = Guid.Parse(id)
+                Dim customer = _customerAdapter.GetByIdAsync(customerId).ConfigureAwait(False).GetAwaiter().GetResult()
+                Return Serialize(customer)
+            Catch ex As Exception
+                Throw New COMException("CRM-CUSTOMER-ERROR", &H8004A100, ex)
+            End Try
+        End Function
+
+        ''' <summary>
+        ''' Retrieves vehicles for a customer serialized to JSON.
+        ''' </summary>
+        Public Function GetVehiclesByCustomerJson(customerId As String) As String
+            Try
+                Dim id = Guid.Parse(customerId)
+                Dim vehicles = _vehicleAdapter.GetByCustomerAsync(id, 100).ConfigureAwait(False).GetAwaiter().GetResult()
+                Return Serialize(vehicles)
+            Catch ex As Exception
+                Throw New COMException("CRM-VEHICLE-ERROR", &H8004A101, ex)
+            End Try
+        End Function
+
+        ''' <summary>
+        ''' Retrieves invoices for a customer serialized to JSON.
+        ''' </summary>
+        Public Function GetInvoicesByCustomerJson(customerId As String) As String
+            Try
+                Dim id = Guid.Parse(customerId)
+                Dim invoices = _invoiceAdapter.GetByCustomerAsync(id, 100).ConfigureAwait(False).GetAwaiter().GetResult()
+                Return Serialize(invoices)
+            Catch ex As Exception
+                Throw New COMException("CRM-INVOICE-ERROR", &H8004A102, ex)
+            End Try
+        End Function
+
+        ''' <summary>
+        ''' Retrieves appointments for a specific date serialized to JSON.
+        ''' </summary>
+        Public Function GetAppointmentsByDateJson([date] As Date) As String
+            Try
+                Dim appointments = _appointmentAdapter.GetByDateAsync([date], 100).ConfigureAwait(False).GetAwaiter().GetResult()
+                Return Serialize(appointments)
+            Catch ex As Exception
+                Throw New COMException("CRM-APPOINTMENT-ERROR", &H8004A103, ex)
+            End Try
+        End Function
+
+        Private Shared Function Serialize(Of T)(value As T) As String
+            If value Is Nothing Then
+                Return String.Empty
+            End If
+
+            Return JsonSerializer.Serialize(value, JsonOptions)
+        End Function
+    End Class
+End Namespace

--- a/CRMAdapter/Vast/Mapping/vast-desktop.json
+++ b/CRMAdapter/Vast/Mapping/vast-desktop.json
@@ -1,0 +1,58 @@
+{
+  "backendName": "VAST Desktop",
+  "mappings": {
+    "Customer": {
+      "__source": "[dbo].[CUSTOMER]",
+      "Id": "[dbo].[CUSTOMER].[CustomerID]",
+      "Name": "[dbo].[CUSTOMER].[FullName]",
+      "Email": "[dbo].[CUSTOMER].[PrimaryEmail]",
+      "Phone": "[dbo].[CUSTOMER].[HomePhone]",
+      "AddressLine1": "[dbo].[CUSTOMER].[Address1]",
+      "AddressLine2": "[dbo].[CUSTOMER].[Address2]",
+      "City": "[dbo].[CUSTOMER].[City]",
+      "State": "[dbo].[CUSTOMER].[State]",
+      "PostalCode": "[dbo].[CUSTOMER].[PostalCode]",
+      "Country": "[dbo].[CUSTOMER].[CountryCode]",
+      "ModifiedOn": "[dbo].[CUSTOMER].[LastModifiedOn]"
+    },
+    "Vehicle": {
+      "__source": "[dbo].[VEHICLE]",
+      "Id": "[dbo].[VEHICLE].[VehicleID]",
+      "CustomerId": "[dbo].[VEHICLE].[CustomerID]",
+      "Vin": "[dbo].[VEHICLE].[VIN]",
+      "Make": "[dbo].[VEHICLE].[Make]",
+      "Model": "[dbo].[VEHICLE].[Model]",
+      "ModelYear": "[dbo].[VEHICLE].[ModelYear]",
+      "Odometer": "[dbo].[VEHICLE].[OdometerMiles]"
+    },
+    "Invoice": {
+      "__source": "[dbo].[INVOICE_HEADER]",
+      "Id": "[dbo].[INVOICE_HEADER].[InvoiceID]",
+      "CustomerId": "[dbo].[INVOICE_HEADER].[CustomerID]",
+      "VehicleId": "[dbo].[INVOICE_HEADER].[VehicleID]",
+      "Number": "[dbo].[INVOICE_HEADER].[InvoiceNumber]",
+      "Date": "[dbo].[INVOICE_HEADER].[InvoiceDate]",
+      "Total": "[dbo].[INVOICE_HEADER].[TotalAmount]",
+      "Status": "[dbo].[INVOICE_HEADER].[StatusCode]"
+    },
+    "InvoiceLine": {
+      "__source": "[dbo].[INVOICE_LINE]",
+      "InvoiceId": "[dbo].[INVOICE_LINE].[InvoiceID]",
+      "Description": "[dbo].[INVOICE_LINE].[Description]",
+      "Quantity": "[dbo].[INVOICE_LINE].[Quantity]",
+      "UnitPrice": "[dbo].[INVOICE_LINE].[UnitPrice]",
+      "Tax": "[dbo].[INVOICE_LINE].[TaxAmount]"
+    },
+    "Appointment": {
+      "__source": "[dbo].[APPOINTMENT]",
+      "Id": "[dbo].[APPOINTMENT].[AppointmentID]",
+      "CustomerId": "[dbo].[APPOINTMENT].[CustomerID]",
+      "VehicleId": "[dbo].[APPOINTMENT].[VehicleID]",
+      "Start": "[dbo].[APPOINTMENT].[StartTimeUtc]",
+      "End": "[dbo].[APPOINTMENT].[EndTimeUtc]",
+      "Advisor": "[dbo].[APPOINTMENT].[AdvisorName]",
+      "Status": "[dbo].[APPOINTMENT].[StatusCode]",
+      "Location": "[dbo].[APPOINTMENT].[LocationName]"
+    }
+  }
+}

--- a/CRMAdapter/Vast/SampleApp/Sample.VBConsole/Program.vb
+++ b/CRMAdapter/Vast/SampleApp/Sample.VBConsole/Program.vb
@@ -1,0 +1,39 @@
+'-----------------------------------------------------------------------
+' File: Program.vb
+' Role: Demonstrates consuming the VAST Desktop adapters from a VB.NET console application.
+' Architectural Purpose: Provides a quickstart for legacy teams to access canonical CRM data via the adapter factory.
+'-----------------------------------------------------------------------
+Option Strict On
+Option Explicit On
+
+Imports System
+Imports System.Data.SqlClient
+Imports System.Text.Json
+Imports CRMAdapter.Factory
+
+Module Program
+    ''' <summary>
+    ''' Sample entry point showing how to bootstrap the adapter factory for VAST Desktop.
+    ''' </summary>
+    Sub Main()
+        Dim connectionString = Environment.GetEnvironmentVariable("CRM_DESKTOP_CONNECTION")
+        If String.IsNullOrWhiteSpace(connectionString) Then
+            Console.WriteLine("Set CRM_DESKTOP_CONNECTION to point to the VAST Desktop SQL Server instance.")
+            Return
+        End If
+
+        Dim mappingPath = "CRMAdapter/Vast/Mapping/vast-desktop.json"
+        Dim adapters = AdapterFactory.CreateVastDesktop(Function() New SqlConnection(connectionString), mappingPath)
+
+        Dim sampleCustomerId = Guid.NewGuid()
+        Dim customer = adapters.CustomerAdapter.GetByIdAsync(sampleCustomerId).GetAwaiter().GetResult()
+        If customer Is Nothing Then
+            Console.WriteLine($"Customer {sampleCustomerId} not found.")
+            Return
+        End If
+
+        Dim json = JsonSerializer.Serialize(customer, New JsonSerializerOptions With {.WriteIndented = True})
+        Console.WriteLine("Canonical Customer Payload:")
+        Console.WriteLine(json)
+    End Sub
+End Module

--- a/CRMAdapter/VastOnline/Adapter/AppointmentAdapter.cs
+++ b/CRMAdapter/VastOnline/Adapter/AppointmentAdapter.cs
@@ -1,0 +1,133 @@
+/*
+ * File: AppointmentAdapter.cs
+ * Role: Implements canonical appointment access for the Vast Online backend.
+ * Architectural Purpose: Normalizes scheduling data from Azure SQL into the CRM canonical appointment aggregate.
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonConfig;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.VastOnline.Adapter
+{
+    /// <summary>
+    /// Vast Online implementation of the <see cref="IAppointmentAdapter"/> contract.
+    /// </summary>
+    public sealed class AppointmentAdapter : SqlAdapterBase, IAppointmentAdapter
+    {
+        private const int DefaultListLimit = 100;
+
+        private static readonly string[] RequiredAppointmentKeys =
+        {
+            "Appointment.__source",
+            "Appointment.Id",
+            "Appointment.CustomerId",
+            "Appointment.VehicleId",
+            "Appointment.Start",
+            "Appointment.End",
+            "Appointment.Advisor",
+            "Appointment.Status",
+            "Appointment.Location"
+        };
+
+        private static readonly string[] AppointmentProjectionFields =
+        {
+            "Id",
+            "CustomerId",
+            "VehicleId",
+            "Start",
+            "End",
+            "Advisor",
+            "Status",
+            "Location"
+        };
+
+        private readonly int _defaultListLimit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppointmentAdapter"/> class.
+        /// </summary>
+        /// <param name="connection">Database connection.</param>
+        /// <param name="fieldMap">Field map configuration.</param>
+        /// <param name="defaultListLimit">Optional default list limit.</param>
+        public AppointmentAdapter(DbConnection connection, FieldMap fieldMap, int defaultListLimit = DefaultListLimit)
+            : base(connection, fieldMap)
+        {
+            _defaultListLimit = defaultListLimit;
+            MappingValidator.EnsureMappings(fieldMap, RequiredAppointmentKeys, nameof(AppointmentAdapter));
+        }
+
+        /// <inheritdoc />
+        public async Task<Appointment?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var fieldMap = FieldMap.GetTargets("Appointment", AppointmentProjectionFields);
+            var source = FieldMap.GetEntitySource("Appointment");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap["Id"]} = @id";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@id", id);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            return ReadAppointment(reader);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Appointment>> GetByDateAsync(
+            DateTime date,
+            int maxResults,
+            CancellationToken cancellationToken = default)
+        {
+            var limit = Math.Min(_defaultListLimit, maxResults > 0 ? maxResults : _defaultListLimit);
+            var fieldMap = FieldMap.GetTargets("Appointment", AppointmentProjectionFields);
+            var source = FieldMap.GetEntitySource("Appointment");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var startField = fieldMap["Start"];
+            var startOfDay = date.Date;
+            var endOfDay = startOfDay.AddDays(1);
+            var commandText = $@"SELECT TOP (@limit) {selectClause}
+FROM {source}
+WHERE {startField} >= @start AND {startField} < @end
+ORDER BY {startField};";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@limit", limit, DbType.Int32);
+            AddParameter(command, "@start", startOfDay, DbType.DateTime2);
+            AddParameter(command, "@end", endOfDay, DbType.DateTime2);
+
+            var appointments = new List<Appointment>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                appointments.Add(ReadAppointment(reader));
+            }
+
+            return new ReadOnlyCollection<Appointment>(appointments);
+        }
+
+        private static Appointment ReadAppointment(DbDataReader reader)
+        {
+            return new Appointment(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")),
+                reader.GetGuid(reader.GetOrdinal("VehicleId")),
+                reader.GetDateTime(reader.GetOrdinal("Start")),
+                reader.GetDateTime(reader.GetOrdinal("End")),
+                reader.GetString(reader.GetOrdinal("Advisor")),
+                reader.GetString(reader.GetOrdinal("Status")),
+                reader.GetString(reader.GetOrdinal("Location")));
+        }
+    }
+}

--- a/CRMAdapter/VastOnline/Adapter/CustomerAdapter.cs
+++ b/CRMAdapter/VastOnline/Adapter/CustomerAdapter.cs
@@ -1,0 +1,312 @@
+/*
+ * File: CustomerAdapter.cs
+ * Role: Implements the canonical customer adapter for the Vast Online backend.
+ * Architectural Purpose: Bridges Azure SQL customer data to the schema-agnostic CRM canonical model.
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonConfig;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.VastOnline.Adapter
+{
+    /// <summary>
+    /// Vast Online implementation of the <see cref="ICustomerAdapter"/> contract.
+    /// </summary>
+    public sealed class CustomerAdapter : SqlAdapterBase, ICustomerAdapter
+    {
+        private const int DefaultSearchLimit = 50;
+        private const int DefaultListLimit = 100;
+
+        private static readonly string[] RequiredCustomerKeys =
+        {
+            "Customer.__source",
+            "Customer.Id",
+            "Customer.Name",
+            "Customer.Email",
+            "Customer.Phone",
+            "Customer.AddressLine1",
+            "Customer.AddressLine2",
+            "Customer.City",
+            "Customer.State",
+            "Customer.PostalCode",
+            "Customer.Country",
+            "Customer.ModifiedOn"
+        };
+
+        private static readonly string[] RequiredVehicleReferenceKeys =
+        {
+            "Vehicle.__source",
+            "Vehicle.Id",
+            "Vehicle.Vin",
+            "Vehicle.CustomerId"
+        };
+
+        private static readonly string[] CustomerProjectionFields =
+        {
+            "Id",
+            "Name",
+            "Email",
+            "Phone",
+            "AddressLine1",
+            "AddressLine2",
+            "City",
+            "State",
+            "PostalCode",
+            "Country"
+        };
+
+        private readonly int _defaultSearchLimit;
+        private readonly int _defaultListLimit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomerAdapter"/> class.
+        /// </summary>
+        /// <param name="connection">Database connection.</param>
+        /// <param name="fieldMap">Schema mapping definition.</param>
+        /// <param name="defaultSearchLimit">Optional default maximum search results.</param>
+        /// <param name="defaultListLimit">Optional default maximum list results.</param>
+        public CustomerAdapter(
+            DbConnection connection,
+            FieldMap fieldMap,
+            int defaultSearchLimit = DefaultSearchLimit,
+            int defaultListLimit = DefaultListLimit)
+            : base(connection, fieldMap)
+        {
+            _defaultSearchLimit = defaultSearchLimit;
+            _defaultListLimit = defaultListLimit;
+            MappingValidator.EnsureMappings(fieldMap, RequiredCustomerKeys, nameof(CustomerAdapter));
+            MappingValidator.EnsureMappings(fieldMap, RequiredVehicleReferenceKeys, nameof(CustomerAdapter));
+        }
+
+        /// <inheritdoc />
+        public async Task<Customer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var fieldMap = FieldMap.GetTargets("Customer", CustomerProjectionFields);
+            var source = FieldMap.GetEntitySource("Customer");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap["Id"]} = @id";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@id", id);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var snapshot = ReadCustomerSnapshot(reader);
+            var vehicleLookup = await LoadVehicleReferencesAsync(new[] { snapshot.Id }, cancellationToken).ConfigureAwait(false);
+            var vehicles = vehicleLookup.TryGetValue(snapshot.Id, out var list)
+                ? list
+                : Array.Empty<VehicleReference>();
+
+            return snapshot.ToCustomer(vehicles);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Customer>> SearchByNameAsync(
+            string nameQuery,
+            int maxResults,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(nameQuery))
+            {
+                throw new ArgumentException("Name query must be supplied.", nameof(nameQuery));
+            }
+
+            var limit = Math.Min(_defaultSearchLimit, maxResults > 0 ? maxResults : _defaultSearchLimit);
+            var fieldMap = FieldMap.GetTargets("Customer", CustomerProjectionFields);
+            var source = FieldMap.GetEntitySource("Customer");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $@"SELECT TOP (@limit) {selectClause}
+FROM {source}
+WHERE {fieldMap["Name"]} LIKE @name
+ORDER BY {fieldMap["Name"]};";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@limit", limit, DbType.Int32);
+            AddParameter(command, "@name", $"%{nameQuery}%");
+
+            var snapshots = await ReadSnapshotsAsync(command, cancellationToken).ConfigureAwait(false);
+            var vehicleLookup = await LoadVehicleReferencesAsync(snapshots.Select(s => s.Id), cancellationToken)
+                .ConfigureAwait(false);
+
+            return new ReadOnlyCollection<Customer>(snapshots
+                .Select(snapshot =>
+                {
+                    var vehicles = vehicleLookup.TryGetValue(snapshot.Id, out var list)
+                        ? list
+                        : Array.Empty<VehicleReference>();
+                    return snapshot.ToCustomer(vehicles);
+                })
+                .ToList());
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Customer>> GetRecentCustomersAsync(
+            int maxResults,
+            CancellationToken cancellationToken = default)
+        {
+            var limit = Math.Min(_defaultListLimit, maxResults > 0 ? maxResults : _defaultListLimit);
+            var fieldMap = FieldMap.GetTargets("Customer", CustomerProjectionFields);
+            var source = FieldMap.GetEntitySource("Customer");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var modifiedOnField = FieldMap.GetTarget("Customer.ModifiedOn");
+            var commandText = $@"SELECT TOP (@limit) {selectClause}
+FROM {source}
+ORDER BY {modifiedOnField} DESC;";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@limit", limit, DbType.Int32);
+
+            var snapshots = await ReadSnapshotsAsync(command, cancellationToken).ConfigureAwait(false);
+            var vehicleLookup = await LoadVehicleReferencesAsync(snapshots.Select(s => s.Id), cancellationToken)
+                .ConfigureAwait(false);
+
+            return new ReadOnlyCollection<Customer>(snapshots
+                .Select(snapshot =>
+                {
+                    var vehicles = vehicleLookup.TryGetValue(snapshot.Id, out var list)
+                        ? list
+                        : Array.Empty<VehicleReference>();
+                    return snapshot.ToCustomer(vehicles);
+                })
+                .ToList());
+        }
+
+        private async Task<IReadOnlyDictionary<Guid, IReadOnlyCollection<VehicleReference>>> LoadVehicleReferencesAsync(
+            IEnumerable<Guid> customerIds,
+            CancellationToken cancellationToken)
+        {
+            var idList = customerIds.Distinct().ToList();
+            if (idList.Count == 0)
+            {
+                return new Dictionary<Guid, IReadOnlyCollection<VehicleReference>>();
+            }
+
+            var fields = FieldMap.GetTargets("Vehicle", new[] { "Id", "Vin", "CustomerId" });
+            var source = FieldMap.GetEntitySource("Vehicle");
+            var parameterNames = idList.Select((_, index) => $"@c{index}").ToArray();
+            var selectClause = $"{fields["Id"]} AS [VehicleId], {fields["Vin"]} AS [Vin], {fields["CustomerId"]} AS [CustomerId]";
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fields["CustomerId"]} IN ({string.Join(", ", parameterNames)})";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            for (var i = 0; i < idList.Count; i++)
+            {
+                AddParameter(command, parameterNames[i], idList[i]);
+            }
+
+            var accumulator = new Dictionary<Guid, List<VehicleReference>>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var customerId = reader.GetGuid(reader.GetOrdinal("CustomerId"));
+                var vehicleId = reader.GetGuid(reader.GetOrdinal("VehicleId"));
+                var vin = reader.GetString(reader.GetOrdinal("Vin"));
+
+                if (!accumulator.TryGetValue(customerId, out var vehicles))
+                {
+                    vehicles = new List<VehicleReference>();
+                    accumulator[customerId] = vehicles;
+                }
+
+                vehicles.Add(new VehicleReference(vehicleId, vin));
+            }
+
+            return accumulator.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyCollection<VehicleReference>)pair.Value.AsReadOnly());
+        }
+
+        private static async Task<List<CustomerSnapshot>> ReadSnapshotsAsync(
+            DbCommand command,
+            CancellationToken cancellationToken)
+        {
+            var snapshots = new List<CustomerSnapshot>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                snapshots.Add(ReadCustomerSnapshot(reader));
+            }
+
+            return snapshots;
+        }
+
+        private static CustomerSnapshot ReadCustomerSnapshot(DbDataReader reader)
+        {
+            return new CustomerSnapshot(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetString(reader.GetOrdinal("Name")),
+                reader.GetString(reader.GetOrdinal("Email")),
+                reader.GetString(reader.GetOrdinal("Phone")),
+                reader.GetString(reader.GetOrdinal("AddressLine1")),
+                reader.IsDBNull(reader.GetOrdinal("AddressLine2")) ? string.Empty : reader.GetString(reader.GetOrdinal("AddressLine2")),
+                reader.GetString(reader.GetOrdinal("City")),
+                reader.GetString(reader.GetOrdinal("State")),
+                reader.GetString(reader.GetOrdinal("PostalCode")),
+                reader.GetString(reader.GetOrdinal("Country")));
+        }
+
+        private sealed class CustomerSnapshot
+        {
+            public CustomerSnapshot(
+                Guid id,
+                string displayName,
+                string email,
+                string primaryPhone,
+                string line1,
+                string line2,
+                string city,
+                string state,
+                string postalCode,
+                string country)
+            {
+                Id = id;
+                DisplayName = displayName;
+                Email = email;
+                PrimaryPhone = primaryPhone;
+                Line1 = line1;
+                Line2 = line2;
+                City = city;
+                State = state;
+                PostalCode = postalCode;
+                Country = country;
+            }
+
+            public Guid Id { get; }
+
+            public string DisplayName { get; }
+
+            public string Email { get; }
+
+            public string PrimaryPhone { get; }
+
+            public string Line1 { get; }
+
+            public string Line2 { get; }
+
+            public string City { get; }
+
+            public string State { get; }
+
+            public string PostalCode { get; }
+
+            public string Country { get; }
+
+            public Customer ToCustomer(IReadOnlyCollection<VehicleReference> vehicles)
+            {
+                var address = new PostalAddress(Line1, Line2, City, State, PostalCode, Country);
+                return new Customer(Id, DisplayName, Email, PrimaryPhone, address, vehicles);
+            }
+        }
+    }
+}

--- a/CRMAdapter/VastOnline/Adapter/InvoiceAdapter.cs
+++ b/CRMAdapter/VastOnline/Adapter/InvoiceAdapter.cs
@@ -1,0 +1,249 @@
+/*
+ * File: InvoiceAdapter.cs
+ * Role: Implements canonical invoice access for the Vast Online backend.
+ * Architectural Purpose: Converts Azure SQL invoice data into the CRM canonical invoice aggregate with line items.
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonConfig;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.VastOnline.Adapter
+{
+    /// <summary>
+    /// Vast Online implementation of the <see cref="IInvoiceAdapter"/> contract.
+    /// </summary>
+    public sealed class InvoiceAdapter : SqlAdapterBase, IInvoiceAdapter
+    {
+        private const int DefaultListLimit = 100;
+
+        private static readonly string[] RequiredInvoiceKeys =
+        {
+            "Invoice.__source",
+            "Invoice.Id",
+            "Invoice.CustomerId",
+            "Invoice.VehicleId",
+            "Invoice.Number",
+            "Invoice.Date",
+            "Invoice.Total",
+            "Invoice.Status"
+        };
+
+        private static readonly string[] RequiredInvoiceLineKeys =
+        {
+            "InvoiceLine.__source",
+            "InvoiceLine.InvoiceId",
+            "InvoiceLine.Description",
+            "InvoiceLine.Quantity",
+            "InvoiceLine.UnitPrice",
+            "InvoiceLine.Tax"
+        };
+
+        private static readonly string[] InvoiceProjectionFields =
+        {
+            "Id",
+            "CustomerId",
+            "VehicleId",
+            "Number",
+            "Date",
+            "Total",
+            "Status"
+        };
+
+        private readonly int _defaultListLimit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvoiceAdapter"/> class.
+        /// </summary>
+        /// <param name="connection">Database connection.</param>
+        /// <param name="fieldMap">Field map configuration.</param>
+        /// <param name="defaultListLimit">Default maximum results for list operations.</param>
+        public InvoiceAdapter(DbConnection connection, FieldMap fieldMap, int defaultListLimit = DefaultListLimit)
+            : base(connection, fieldMap)
+        {
+            _defaultListLimit = defaultListLimit;
+            MappingValidator.EnsureMappings(fieldMap, RequiredInvoiceKeys, nameof(InvoiceAdapter));
+            MappingValidator.EnsureMappings(fieldMap, RequiredInvoiceLineKeys, nameof(InvoiceAdapter));
+        }
+
+        /// <inheritdoc />
+        public async Task<Invoice?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var fieldMap = FieldMap.GetTargets("Invoice", InvoiceProjectionFields);
+            var source = FieldMap.GetEntitySource("Invoice");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap["Id"]} = @id";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@id", id);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var invoice = ReadInvoice(reader);
+            var lines = await LoadInvoiceLinesAsync(new[] { invoice.Id }, cancellationToken).ConfigureAwait(false);
+            var lineItems = lines.TryGetValue(invoice.Id, out var collection)
+                ? collection
+                : Array.Empty<InvoiceLine>();
+
+            return new Invoice(
+                invoice.Id,
+                invoice.CustomerId,
+                invoice.VehicleId,
+                invoice.InvoiceNumber,
+                invoice.InvoiceDate,
+                invoice.TotalAmount,
+                invoice.Status,
+                lineItems);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Invoice>> GetByCustomerAsync(
+            Guid customerId,
+            int maxResults,
+            CancellationToken cancellationToken = default)
+        {
+            var limit = Math.Min(_defaultListLimit, maxResults > 0 ? maxResults : _defaultListLimit);
+            var fieldMap = FieldMap.GetTargets("Invoice", InvoiceProjectionFields);
+            var source = FieldMap.GetEntitySource("Invoice");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $@"SELECT TOP (@limit) {selectClause}
+FROM {source}
+WHERE {fieldMap["CustomerId"]} = @customerId
+ORDER BY {fieldMap["Date"]} DESC;";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@limit", limit, DbType.Int32);
+            AddParameter(command, "@customerId", customerId);
+
+            var invoices = new List<InvoiceRecord>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                invoices.Add(ReadInvoice(reader));
+            }
+
+            var lineLookup = await LoadInvoiceLinesAsync(invoices.Select(i => i.Id), cancellationToken).ConfigureAwait(false);
+            var results = invoices.Select(record =>
+            {
+                var lines = lineLookup.TryGetValue(record.Id, out var items)
+                    ? items
+                    : Array.Empty<InvoiceLine>();
+                return new Invoice(
+                    record.Id,
+                    record.CustomerId,
+                    record.VehicleId,
+                    record.InvoiceNumber,
+                    record.InvoiceDate,
+                    record.TotalAmount,
+                    record.Status,
+                    lines);
+            }).ToList();
+
+            return new ReadOnlyCollection<Invoice>(results);
+        }
+
+        private async Task<IReadOnlyDictionary<Guid, IReadOnlyCollection<InvoiceLine>>> LoadInvoiceLinesAsync(
+            IEnumerable<Guid> invoiceIds,
+            CancellationToken cancellationToken)
+        {
+            var ids = invoiceIds.Distinct().ToList();
+            if (ids.Count == 0)
+            {
+                return new Dictionary<Guid, IReadOnlyCollection<InvoiceLine>>();
+            }
+
+            var fields = FieldMap.GetTargets("InvoiceLine", new[] { "InvoiceId", "Description", "Quantity", "UnitPrice", "Tax" });
+            var source = FieldMap.GetEntitySource("InvoiceLine");
+            var parameterNames = ids.Select((_, index) => $"@i{index}").ToArray();
+            var selectClause = $"{fields["InvoiceId"]} AS [InvoiceId], {fields["Description"]} AS [Description], {fields["Quantity"]} AS [Quantity], {fields["UnitPrice"]} AS [UnitPrice], {fields["Tax"]} AS [Tax]";
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fields["InvoiceId"]} IN ({string.Join(", ", parameterNames)})";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            for (var i = 0; i < ids.Count; i++)
+            {
+                AddParameter(command, parameterNames[i], ids[i]);
+            }
+
+            var accumulator = new Dictionary<Guid, List<InvoiceLine>>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var invoiceId = reader.GetGuid(reader.GetOrdinal("InvoiceId"));
+                var description = reader.GetString(reader.GetOrdinal("Description"));
+                var quantity = reader.GetDecimal(reader.GetOrdinal("Quantity"));
+                var unitPrice = reader.GetDecimal(reader.GetOrdinal("UnitPrice"));
+                var tax = reader.GetDecimal(reader.GetOrdinal("Tax"));
+
+                if (!accumulator.TryGetValue(invoiceId, out var list))
+                {
+                    list = new List<InvoiceLine>();
+                    accumulator[invoiceId] = list;
+                }
+
+                list.Add(new InvoiceLine(description, quantity, unitPrice, tax));
+            }
+
+            return accumulator.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyCollection<InvoiceLine>)pair.Value.AsReadOnly());
+        }
+
+        private static InvoiceRecord ReadInvoice(DbDataReader reader)
+        {
+            return new InvoiceRecord(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")),
+                reader.GetGuid(reader.GetOrdinal("VehicleId")),
+                reader.GetString(reader.GetOrdinal("Number")),
+                reader.GetDateTime(reader.GetOrdinal("Date")),
+                reader.GetDecimal(reader.GetOrdinal("Total")),
+                reader.GetString(reader.GetOrdinal("Status")));
+        }
+
+        private sealed class InvoiceRecord
+        {
+            public InvoiceRecord(
+                Guid id,
+                Guid customerId,
+                Guid vehicleId,
+                string invoiceNumber,
+                DateTime invoiceDate,
+                decimal totalAmount,
+                string status)
+            {
+                Id = id;
+                CustomerId = customerId;
+                VehicleId = vehicleId;
+                InvoiceNumber = invoiceNumber;
+                InvoiceDate = invoiceDate;
+                TotalAmount = totalAmount;
+                Status = status;
+            }
+
+            public Guid Id { get; }
+
+            public Guid CustomerId { get; }
+
+            public Guid VehicleId { get; }
+
+            public string InvoiceNumber { get; }
+
+            public DateTime InvoiceDate { get; }
+
+            public decimal TotalAmount { get; }
+
+            public string Status { get; }
+        }
+    }
+}

--- a/CRMAdapter/VastOnline/Adapter/SqlAdapterBase.cs
+++ b/CRMAdapter/VastOnline/Adapter/SqlAdapterBase.cs
@@ -1,0 +1,143 @@
+/*
+ * File: SqlAdapterBase.cs
+ * Role: Provides shared SQL helper functionality for Vast Online adapters.
+ * Architectural Purpose: Centralizes connection management and parameter creation for consistent async data access.
+ */
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonConfig;
+
+namespace CRMAdapter.VastOnline.Adapter
+{
+    /// <summary>
+    /// Base class providing shared SQL helper methods for adapter implementations.
+    /// </summary>
+    public abstract class SqlAdapterBase : IDisposable
+    {
+        private bool _disposed;
+        private readonly SemaphoreSlim _connectionLock = new(1, 1);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlAdapterBase"/> class.
+        /// </summary>
+        /// <param name="connection">Database connection.</param>
+        /// <param name="fieldMap">Schema field mapping.</param>
+        protected SqlAdapterBase(DbConnection connection, FieldMap fieldMap)
+        {
+            Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            FieldMap = fieldMap ?? throw new ArgumentNullException(nameof(fieldMap));
+        }
+
+        /// <summary>
+        /// Gets the database connection used by the adapter.
+        /// </summary>
+        protected DbConnection Connection { get; }
+
+        /// <summary>
+        /// Gets the field map used by the adapter.
+        /// </summary>
+        protected FieldMap FieldMap { get; }
+
+        /// <summary>
+        /// Creates a command with the provided text after ensuring the connection is open.
+        /// </summary>
+        /// <param name="commandText">SQL command text.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An initialized <see cref="DbCommand"/>.</returns>
+        protected async Task<DbCommand> CreateCommandAsync(string commandText, CancellationToken cancellationToken)
+        {
+            if (commandText is null)
+            {
+                throw new ArgumentNullException(nameof(commandText));
+            }
+
+            await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+            var command = Connection.CreateCommand();
+            command.CommandText = commandText;
+            command.CommandType = CommandType.Text;
+            return command;
+        }
+
+        /// <summary>
+        /// Adds a parameter with the supplied metadata to the command.
+        /// </summary>
+        /// <param name="command">Command to add the parameter to.</param>
+        /// <param name="name">Parameter name.</param>
+        /// <param name="value">Parameter value.</param>
+        /// <param name="dbType">Optional database type.</param>
+        protected static void AddParameter(DbCommand command, string name, object? value, DbType? dbType = null)
+        {
+            if (command is null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value ?? DBNull.Value;
+            if (dbType.HasValue)
+            {
+                parameter.DbType = dbType.Value;
+            }
+
+            command.Parameters.Add(parameter);
+        }
+
+        /// <summary>
+        /// Disposes managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the underlying connection.
+        /// </summary>
+        /// <param name="disposing">Indicates whether managed resources should be disposed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Connection.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        private async Task EnsureConnectionAsync(CancellationToken cancellationToken)
+        {
+            if (Connection.State == ConnectionState.Open)
+            {
+                return;
+            }
+
+            await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (Connection.State != ConnectionState.Open)
+                {
+                    await Connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _connectionLock.Release();
+            }
+        }
+    }
+}

--- a/CRMAdapter/VastOnline/Adapter/VehicleAdapter.cs
+++ b/CRMAdapter/VastOnline/Adapter/VehicleAdapter.cs
@@ -1,0 +1,126 @@
+/*
+ * File: VehicleAdapter.cs
+ * Role: Implements canonical vehicle access for the Vast Online backend.
+ * Architectural Purpose: Normalizes vehicle data retrieved from Azure SQL into the CRM canonical model.
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonConfig;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+
+namespace CRMAdapter.VastOnline.Adapter
+{
+    /// <summary>
+    /// Vast Online implementation of the <see cref="IVehicleAdapter"/> contract.
+    /// </summary>
+    public sealed class VehicleAdapter : SqlAdapterBase, IVehicleAdapter
+    {
+        private const int DefaultListLimit = 100;
+
+        private static readonly string[] RequiredVehicleKeys =
+        {
+            "Vehicle.__source",
+            "Vehicle.Id",
+            "Vehicle.CustomerId",
+            "Vehicle.Vin",
+            "Vehicle.Make",
+            "Vehicle.Model",
+            "Vehicle.ModelYear",
+            "Vehicle.Odometer"
+        };
+
+        private static readonly string[] VehicleProjectionFields =
+        {
+            "Id",
+            "CustomerId",
+            "Vin",
+            "Make",
+            "Model",
+            "ModelYear",
+            "Odometer"
+        };
+
+        private readonly int _defaultListLimit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VehicleAdapter"/> class.
+        /// </summary>
+        /// <param name="connection">Database connection.</param>
+        /// <param name="fieldMap">Field map configuration.</param>
+        /// <param name="defaultListLimit">Default maximum rows returned for list operations.</param>
+        public VehicleAdapter(DbConnection connection, FieldMap fieldMap, int defaultListLimit = DefaultListLimit)
+            : base(connection, fieldMap)
+        {
+            _defaultListLimit = defaultListLimit;
+            MappingValidator.EnsureMappings(fieldMap, RequiredVehicleKeys, nameof(VehicleAdapter));
+        }
+
+        /// <inheritdoc />
+        public async Task<Vehicle?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var fieldMap = FieldMap.GetTargets("Vehicle", VehicleProjectionFields);
+            var source = FieldMap.GetEntitySource("Vehicle");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $"SELECT {selectClause} FROM {source} WHERE {fieldMap["Id"]} = @id";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@id", id);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            return ReadVehicle(reader);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Vehicle>> GetByCustomerAsync(
+            Guid customerId,
+            int maxResults,
+            CancellationToken cancellationToken = default)
+        {
+            var limit = Math.Min(_defaultListLimit, maxResults > 0 ? maxResults : _defaultListLimit);
+            var fieldMap = FieldMap.GetTargets("Vehicle", VehicleProjectionFields);
+            var source = FieldMap.GetEntitySource("Vehicle");
+            var selectClause = string.Join(", ", fieldMap.Select(kvp => $"{kvp.Value} AS [{kvp.Key}]"));
+            var commandText = $@"SELECT TOP (@limit) {selectClause}
+FROM {source}
+WHERE {fieldMap["CustomerId"]} = @customerId
+ORDER BY {fieldMap["ModelYear"]} DESC, {fieldMap["Make"]}, {fieldMap["Model"]};";
+
+            await using var command = await CreateCommandAsync(commandText, cancellationToken).ConfigureAwait(false);
+            AddParameter(command, "@limit", limit, DbType.Int32);
+            AddParameter(command, "@customerId", customerId);
+
+            var vehicles = new List<Vehicle>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                vehicles.Add(ReadVehicle(reader));
+            }
+
+            return new ReadOnlyCollection<Vehicle>(vehicles);
+        }
+
+        private static Vehicle ReadVehicle(DbDataReader reader)
+        {
+            return new Vehicle(
+                reader.GetGuid(reader.GetOrdinal("Id")),
+                reader.GetString(reader.GetOrdinal("Vin")),
+                reader.GetString(reader.GetOrdinal("Make")),
+                reader.GetString(reader.GetOrdinal("Model")),
+                reader.GetInt32(reader.GetOrdinal("ModelYear")),
+                reader.GetInt32(reader.GetOrdinal("Odometer")),
+                reader.GetGuid(reader.GetOrdinal("CustomerId")));
+        }
+    }
+}

--- a/CRMAdapter/VastOnline/Mapping/vast-online.json
+++ b/CRMAdapter/VastOnline/Mapping/vast-online.json
@@ -1,0 +1,58 @@
+{
+  "backendName": "VAST Online",
+  "mappings": {
+    "Customer": {
+      "__source": "[crm].[Customer]",
+      "Id": "[crm].[Customer].[CustomerGuid]",
+      "Name": "[crm].[Customer].[DisplayName]",
+      "Email": "[crm].[Customer].[EmailPrimary]",
+      "Phone": "[crm].[Customer].[PhonePrimary]",
+      "AddressLine1": "[crm].[Customer].[AddressLine1]",
+      "AddressLine2": "[crm].[Customer].[AddressLine2]",
+      "City": "[crm].[Customer].[City]",
+      "State": "[crm].[Customer].[StateProvince]",
+      "PostalCode": "[crm].[Customer].[PostalCode]",
+      "Country": "[crm].[Customer].[CountryCode]",
+      "ModifiedOn": "[crm].[Customer].[ModifiedUtc]"
+    },
+    "Vehicle": {
+      "__source": "[crm].[Vehicle]",
+      "Id": "[crm].[Vehicle].[VehicleGuid]",
+      "CustomerId": "[crm].[Vehicle].[CustomerGuid]",
+      "Vin": "[crm].[Vehicle].[Vin]",
+      "Make": "[crm].[Vehicle].[Make]",
+      "Model": "[crm].[Vehicle].[Model]",
+      "ModelYear": "[crm].[Vehicle].[ModelYear]",
+      "Odometer": "[crm].[Vehicle].[OdometerMiles]"
+    },
+    "Invoice": {
+      "__source": "[billing].[Invoice]",
+      "Id": "[billing].[Invoice].[InvoiceGuid]",
+      "CustomerId": "[billing].[Invoice].[CustomerGuid]",
+      "VehicleId": "[billing].[Invoice].[VehicleGuid]",
+      "Number": "[billing].[Invoice].[InvoiceNumber]",
+      "Date": "[billing].[Invoice].[InvoiceDateUtc]",
+      "Total": "[billing].[Invoice].[InvoiceTotal]",
+      "Status": "[billing].[Invoice].[Status]"
+    },
+    "InvoiceLine": {
+      "__source": "[billing].[InvoiceLine]",
+      "InvoiceId": "[billing].[InvoiceLine].[InvoiceGuid]",
+      "Description": "[billing].[InvoiceLine].[Description]",
+      "Quantity": "[billing].[InvoiceLine].[Quantity]",
+      "UnitPrice": "[billing].[InvoiceLine].[UnitPrice]",
+      "Tax": "[billing].[InvoiceLine].[TaxAmount]"
+    },
+    "Appointment": {
+      "__source": "[scheduling].[Appointment]",
+      "Id": "[scheduling].[Appointment].[AppointmentGuid]",
+      "CustomerId": "[scheduling].[Appointment].[CustomerGuid]",
+      "VehicleId": "[scheduling].[Appointment].[VehicleGuid]",
+      "Start": "[scheduling].[Appointment].[StartTimeUtc]",
+      "End": "[scheduling].[Appointment].[EndTimeUtc]",
+      "Advisor": "[scheduling].[Appointment].[AdvisorDisplayName]",
+      "Status": "[scheduling].[Appointment].[Status]",
+      "Location": "[scheduling].[Appointment].[LocationName]"
+    }
+  }
+}

--- a/CRMAdapter/VastOnline/SampleApp/Sample.BlazorServer/Pages/Customers.razor
+++ b/CRMAdapter/VastOnline/SampleApp/Sample.BlazorServer/Pages/Customers.razor
@@ -1,0 +1,52 @@
+@*-----------------------------------------------------------------------
+ File: Customers.razor
+ Role: Demonstrates consuming the Vast Online customer adapter within a Blazor component.
+ Architectural Purpose: Showcases dependency injection and async data binding against the canonical CRM domain.
+-----------------------------------------------------------------------*@
+@page "/customers"
+@using CRMAdapter.CommonContracts
+@using CRMAdapter.CommonDomain
+@inject ICustomerAdapter CustomerAdapter
+
+<h3>Recent Customers</h3>
+
+@if (_customers is null)
+{
+    <p><em>Loading customers...</em></p>
+}
+else if (_customers.Count == 0)
+{
+    <p>No customers were returned from the adapter.</p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Phone</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var customer in _customers)
+            {
+                <tr>
+                    <td>@customer.DisplayName</td>
+                    <td>@customer.Email</td>
+                    <td>@customer.PrimaryPhone</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private IReadOnlyCollection<Customer>? _customers;
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        _customers = await CustomerAdapter.GetRecentCustomersAsync(25);
+    }
+}

--- a/CRMAdapter/VastOnline/SampleApp/Sample.BlazorServer/Program.cs
+++ b/CRMAdapter/VastOnline/SampleApp/Sample.BlazorServer/Program.cs
@@ -1,0 +1,42 @@
+/*
+ * File: Program.cs
+ * Role: Demonstrates integrating Vast Online adapters into a Blazor Server application.
+ * Architectural Purpose: Showcases dependency injection registration and usage of the schema-agnostic adapters.
+ */
+using System;
+using System.Data.Common;
+using System.Data.SqlClient;
+using CRMAdapter.Factory;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var mappingPath = builder.Configuration["CRM:MappingPath"] ?? "CRMAdapter/VastOnline/Mapping/vast-online.json";
+var connectionString = builder.Configuration.GetConnectionString("VastOnline")
+    ?? throw new InvalidOperationException("Configure the VastOnline connection string in appsettings.json.");
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+builder.Services.AddVastOnlineAdapters(mappingPath, _ =>
+{
+    DbConnection connection = new SqlConnection(connectionString);
+    return connection;
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();


### PR DESCRIPTION
## Summary
- implement canonical CRM domain classes and adapter contracts for customers, vehicles, invoices, and appointments
- add config-driven field mapping loader with validation and factory capable of instantiating VAST Desktop or VAST Online adapters
- provide VB.NET and C# adapters, COM wrapper, and sample apps showcasing VB console and Blazor Server integration

## Testing
- not run (infrastructure only)

------
https://chatgpt.com/codex/tasks/task_e_68d34d38d1c8832f91410fb391017abd