### PR TITLE
Add canonical CRM minimal API host with JWT security

### DIFF
--- a/CRMAdapter/CRMAdapter.Api/CRMAdapter.Api.csproj
+++ b/CRMAdapter/CRMAdapter.Api/CRMAdapter.Api.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DocumentationFile>Docs/openapi.xml</DocumentationFile>
+    <RootNamespace>CRMAdapter.Api</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CRMAdapter.Core\CRMAdapter.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.3" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Config\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Config\appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <None Include="Docs\openapi.xml" />
+    <Content Include="..\Vast\Mapping\vast-desktop.json">
+      <Link>Mappings\vast-desktop.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\VastOnline\Mapping\vast-online.json">
+      <Link>Mappings\vast-online.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/CRMAdapter/CRMAdapter.Api/Config/appsettings.Development.json
+++ b/CRMAdapter/CRMAdapter.Api/Config/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  },
+  "CRM": {
+    "Backend": "VAST_ONLINE"
+  }
+}

--- a/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
+++ b/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
@@ -1,0 +1,38 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "EventLog": {
+      "Source": "CRMAdapter.Api",
+      "LogName": "Application"
+    },
+    "ApplicationInsights": {
+      "ConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/",
+      "RoleName": "crm-adapter-api"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "VastDesktop": "Server=localhost;Database=VastDesktop;Trusted_Connection=True;Encrypt=False;",
+    "VastOnline": "Server=localhost;Database=VastOnline;Trusted_Connection=True;Encrypt=False;"
+  },
+  "CRM": {
+    "Backend": "VAST_DESKTOP",
+    "Mapping": {
+      "VAST_DESKTOP": "Mappings/vast-desktop.json",
+      "VAST_ONLINE": "Mappings/vast-online.json"
+    },
+    "Adapters": {
+      "MaxConcurrency": 16
+    }
+  },
+  "Jwt": {
+    "Issuer": "crm-adapter-api",
+    "Audience": "crm-clients",
+    "SigningKey": "SuperSecureSigningKeyForCanonicalAdapter123!",
+    "RequireHttpsMetadata": false,
+    "ClockSkew": "00:05:00"
+  }
+}

--- a/CRMAdapter/CRMAdapter.Api/Docs/openapi.xml
+++ b/CRMAdapter/CRMAdapter.Api/Docs/openapi.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  File: openapi.xml
+  Summary: Placeholder XML documentation file generated at build time for Swagger annotations.
+-->
+<doc>
+  <assembly>
+    <name>CRMAdapter.Api</name>
+  </assembly>
+  <members>
+  </members>
+</doc>

--- a/CRMAdapter/CRMAdapter.Api/Endpoints/AppointmentsEndpoint.cs
+++ b/CRMAdapter/CRMAdapter.Api/Endpoints/AppointmentsEndpoint.cs
@@ -1,0 +1,84 @@
+// File: AppointmentsEndpoint.cs
+// Summary: Declares appointment-specific endpoint mappings over the canonical adapter abstraction.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Endpoints;
+
+/// <summary>
+/// Maps canonical appointment retrieval endpoints.
+/// </summary>
+public static class AppointmentsEndpoint
+{
+    /// <summary>
+    /// Registers appointment endpoints on the supplied route builder.
+    /// </summary>
+    /// <param name="endpoints">Endpoint route builder.</param>
+    /// <returns>The configured route group builder.</returns>
+    public static RouteGroupBuilder MapAppointmentsEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        if (endpoints is null)
+        {
+            throw new ArgumentNullException(nameof(endpoints));
+        }
+
+        var group = endpoints.MapGroup("/appointments").WithTags("Appointments").WithOpenApi();
+
+        group.MapGet("/{id:guid}", GetAppointmentByIdAsync)
+            .WithName("GetAppointmentById")
+            .WithSummary("Retrieves a canonical appointment by identifier.")
+            .WithDescription("Returns the canonical appointment representation produced by the adapter layer.")
+            .RequireAuthorization(AuthPolicies.AppointmentRead)
+            .Produces<Appointment>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<Appointment>, ProblemHttpResult>> GetAppointmentByIdAsync(
+        Guid id,
+        HttpContext httpContext,
+        IAppointmentAdapter adapter,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        if (adapter is null)
+        {
+            throw new ArgumentNullException(nameof(adapter));
+        }
+
+        var logger = loggerFactory.CreateLogger(typeof(AppointmentsEndpoint));
+        logger.LogInformation("Resolving appointment {AppointmentId}.", id);
+
+        var appointment = await adapter.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (appointment is null)
+        {
+            logger.LogWarning("Appointment {AppointmentId} was not found.", id);
+            return TypedResults.Problem(CreateNotFoundProblem(httpContext, $"Appointment '{id}' was not located."));
+        }
+
+        return TypedResults.Ok(appointment);
+    }
+
+    private static ProblemDetails CreateNotFoundProblem(HttpContext context, string detail)
+    {
+        return new ProblemDetails
+        {
+            Title = "Resource not found.",
+            Detail = detail,
+            Status = StatusCodes.Status404NotFound,
+            Instance = context?.Request.Path.ToString(),
+            Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+        };
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Endpoints/CustomersEndpoint.cs
+++ b/CRMAdapter/CRMAdapter.Api/Endpoints/CustomersEndpoint.cs
@@ -1,0 +1,150 @@
+// File: CustomersEndpoint.cs
+// Summary: Declares customer-specific endpoint mappings and request contracts.
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Endpoints;
+
+/// <summary>
+/// Maps canonical customer operations to minimal API endpoints.
+/// </summary>
+public static class CustomersEndpoint
+{
+    private const int DefaultMaxResults = 50;
+    private const int MaxAllowedResults = 500;
+
+    /// <summary>
+    /// Registers customer endpoints on the supplied route builder.
+    /// </summary>
+    /// <param name="endpoints">Endpoint builder used to map HTTP routes.</param>
+    /// <returns>The configured route group builder.</returns>
+    public static RouteGroupBuilder MapCustomersEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        if (endpoints is null)
+        {
+            throw new ArgumentNullException(nameof(endpoints));
+        }
+
+        var group = endpoints.MapGroup("/customers").WithTags("Customers").WithOpenApi();
+
+        group.MapGet("/{id:guid}", GetCustomerByIdAsync)
+            .WithName("GetCustomerById")
+            .WithSummary("Retrieves a canonical customer by identifier.")
+            .WithDescription("Returns the canonical customer aggregate projected by the configured adapter.")
+            .RequireAuthorization(AuthPolicies.CustomerRead)
+            .Produces<Customer>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
+
+        group.MapPost("/search", SearchCustomersAsync)
+            .WithName("SearchCustomers")
+            .WithSummary("Performs a canonical customer search.")
+            .WithDescription("Invokes the configured adapter search pipeline using canonical semantics.")
+            .RequireAuthorization(AuthPolicies.CustomerSearch)
+            .Produces<IReadOnlyCollection<Customer>>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<Customer>, ProblemHttpResult>> GetCustomerByIdAsync(
+        Guid id,
+        HttpContext httpContext,
+        ICustomerAdapter adapter,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        if (adapter is null)
+        {
+            throw new ArgumentNullException(nameof(adapter));
+        }
+
+        var logger = loggerFactory.CreateLogger(typeof(CustomersEndpoint));
+        logger.LogInformation("Resolving customer {CustomerId}.", id);
+
+        var customer = await adapter.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (customer is null)
+        {
+            logger.LogWarning("Customer {CustomerId} was not found.", id);
+            return TypedResults.Problem(CreateNotFoundProblem(httpContext, $"Customer '{id}' was not located."));
+        }
+
+        return TypedResults.Ok(customer);
+    }
+
+    private static async Task<Results<Ok<IReadOnlyCollection<Customer>>, ProblemHttpResult>> SearchCustomersAsync(
+        CustomerSearchRequest request,
+        ICustomerAdapter adapter,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        if (adapter is null)
+        {
+            throw new ArgumentNullException(nameof(adapter));
+        }
+
+        if (request is null)
+        {
+            return TypedResults.Problem(new ProblemDetails
+            {
+                Title = "Invalid request payload.",
+                Detail = "Request body cannot be empty.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Query))
+        {
+            return TypedResults.Problem(new ProblemDetails
+            {
+                Title = "Invalid search criteria.",
+                Detail = "A search query must be supplied.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        var normalizedMax = Math.Clamp(request.MaxResults ?? DefaultMaxResults, 1, MaxAllowedResults);
+        var normalizedQuery = request.Query.Trim();
+        var logger = loggerFactory.CreateLogger(typeof(CustomersEndpoint));
+        logger.LogInformation("Executing customer search for '{Query}' with limit {Limit}.", normalizedQuery, normalizedMax);
+
+        var results = await adapter.SearchByNameAsync(normalizedQuery, normalizedMax, cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(results);
+    }
+
+    private static ProblemDetails CreateNotFoundProblem(HttpContext context, string detail)
+    {
+        return new ProblemDetails
+        {
+            Title = "Resource not found.",
+            Detail = detail,
+            Status = StatusCodes.Status404NotFound,
+            Instance = context?.Request.Path.ToString(),
+            Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+        };
+    }
+}
+
+/// <summary>
+/// Request payload used to trigger canonical customer search queries.
+/// </summary>
+/// <param name="Query">Name fragment or identifier to search for.</param>
+/// <param name="MaxResults">Optional limit on the number of results (defaults to 50).</param>
+public sealed record CustomerSearchRequest(
+    [property: Required] string Query,
+    [property: Range(1, MaxAllowedResults)] int? MaxResults)
+{
+    private const int MaxAllowedResults = 500;
+}

--- a/CRMAdapter/CRMAdapter.Api/Endpoints/InvoicesEndpoint.cs
+++ b/CRMAdapter/CRMAdapter.Api/Endpoints/InvoicesEndpoint.cs
@@ -1,0 +1,84 @@
+// File: InvoicesEndpoint.cs
+// Summary: Declares invoice-specific endpoint mappings over the canonical adapter abstraction.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Endpoints;
+
+/// <summary>
+/// Maps canonical invoice retrieval endpoints.
+/// </summary>
+public static class InvoicesEndpoint
+{
+    /// <summary>
+    /// Registers invoice endpoints on the supplied route builder.
+    /// </summary>
+    /// <param name="endpoints">Endpoint route builder.</param>
+    /// <returns>The configured route group builder.</returns>
+    public static RouteGroupBuilder MapInvoicesEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        if (endpoints is null)
+        {
+            throw new ArgumentNullException(nameof(endpoints));
+        }
+
+        var group = endpoints.MapGroup("/invoices").WithTags("Invoices").WithOpenApi();
+
+        group.MapGet("/{id:guid}", GetInvoiceByIdAsync)
+            .WithName("GetInvoiceById")
+            .WithSummary("Retrieves a canonical invoice by identifier.")
+            .WithDescription("Returns the canonical invoice projection produced by the adapter layer.")
+            .RequireAuthorization(AuthPolicies.InvoiceRead)
+            .Produces<Invoice>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<Invoice>, ProblemHttpResult>> GetInvoiceByIdAsync(
+        Guid id,
+        HttpContext httpContext,
+        IInvoiceAdapter adapter,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        if (adapter is null)
+        {
+            throw new ArgumentNullException(nameof(adapter));
+        }
+
+        var logger = loggerFactory.CreateLogger(typeof(InvoicesEndpoint));
+        logger.LogInformation("Resolving invoice {InvoiceId}.", id);
+
+        var invoice = await adapter.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (invoice is null)
+        {
+            logger.LogWarning("Invoice {InvoiceId} was not found.", id);
+            return TypedResults.Problem(CreateNotFoundProblem(httpContext, $"Invoice '{id}' was not located."));
+        }
+
+        return TypedResults.Ok(invoice);
+    }
+
+    private static ProblemDetails CreateNotFoundProblem(HttpContext context, string detail)
+    {
+        return new ProblemDetails
+        {
+            Title = "Resource not found.",
+            Detail = detail,
+            Status = StatusCodes.Status404NotFound,
+            Instance = context?.Request.Path.ToString(),
+            Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+        };
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Endpoints/VehiclesEndpoint.cs
+++ b/CRMAdapter/CRMAdapter.Api/Endpoints/VehiclesEndpoint.cs
@@ -1,0 +1,84 @@
+// File: VehiclesEndpoint.cs
+// Summary: Declares vehicle-specific endpoint mappings over the canonical adapter abstraction.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Endpoints;
+
+/// <summary>
+/// Maps canonical vehicle retrieval operations.
+/// </summary>
+public static class VehiclesEndpoint
+{
+    /// <summary>
+    /// Registers vehicle endpoints on the supplied route builder.
+    /// </summary>
+    /// <param name="endpoints">Endpoint route builder.</param>
+    /// <returns>The configured route group builder.</returns>
+    public static RouteGroupBuilder MapVehiclesEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        if (endpoints is null)
+        {
+            throw new ArgumentNullException(nameof(endpoints));
+        }
+
+        var group = endpoints.MapGroup("/vehicles").WithTags("Vehicles").WithOpenApi();
+
+        group.MapGet("/{id:guid}", GetVehicleByIdAsync)
+            .WithName("GetVehicleById")
+            .WithSummary("Retrieves a canonical vehicle by identifier.")
+            .WithDescription("Returns the canonical vehicle aggregate exposed by the adapter layer.")
+            .RequireAuthorization(AuthPolicies.VehicleRead)
+            .Produces<Vehicle>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<Vehicle>, ProblemHttpResult>> GetVehicleByIdAsync(
+        Guid id,
+        HttpContext httpContext,
+        IVehicleAdapter adapter,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        if (adapter is null)
+        {
+            throw new ArgumentNullException(nameof(adapter));
+        }
+
+        var logger = loggerFactory.CreateLogger(typeof(VehiclesEndpoint));
+        logger.LogInformation("Resolving vehicle {VehicleId}.", id);
+
+        var vehicle = await adapter.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (vehicle is null)
+        {
+            logger.LogWarning("Vehicle {VehicleId} was not found.", id);
+            return TypedResults.Problem(CreateNotFoundProblem(httpContext, $"Vehicle '{id}' was not located."));
+        }
+
+        return TypedResults.Ok(vehicle);
+    }
+
+    private static ProblemDetails CreateNotFoundProblem(HttpContext context, string detail)
+    {
+        return new ProblemDetails
+        {
+            Title = "Resource not found.",
+            Detail = detail,
+            Status = StatusCodes.Status404NotFound,
+            Instance = context?.Request.Path.ToString(),
+            Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+        };
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Logging/SerilogConfig.cs
+++ b/CRMAdapter/CRMAdapter.Api/Logging/SerilogConfig.cs
@@ -1,0 +1,98 @@
+// File: SerilogConfig.cs
+// Summary: Configures Serilog sinks and enrichers for the API host.
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters;
+
+namespace CRMAdapter.Api.Logging;
+
+/// <summary>
+/// Provides helper methods for wiring Serilog into the web application host.
+/// </summary>
+public static class SerilogConfig
+{
+    /// <summary>
+    /// Configures Serilog using environment-aware sinks.
+    /// </summary>
+    /// <param name="builder">Web application builder.</param>
+    public static void Configure(WebApplicationBuilder builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.Host.UseSerilog((context, services, loggerConfiguration) =>
+        {
+            ConfigureLogger(context.Configuration, loggerConfiguration);
+        });
+    }
+
+    private static void ConfigureLogger(
+        IConfiguration configuration,
+        LoggerConfiguration loggerConfiguration)
+    {
+        var backend = configuration["CRM:Backend"]
+            ?? Environment.GetEnvironmentVariable("CRM_BACKEND")
+            ?? "VAST_DESKTOP";
+
+        loggerConfiguration
+            .ReadFrom.Configuration(configuration)
+            .Enrich.FromLogContext()
+            .Enrich.WithEnvironmentName()
+            .Enrich.WithMachineName()
+            .Enrich.WithProcessId()
+            .Enrich.WithThreadId()
+            .WriteTo.Console();
+
+        if (string.Equals(backend, "VAST_DESKTOP", StringComparison.OrdinalIgnoreCase))
+        {
+            ConfigureDesktopSink(configuration, loggerConfiguration);
+        }
+        else
+        {
+            ConfigureOnlineSink(configuration, loggerConfiguration);
+        }
+    }
+
+    private static void ConfigureDesktopSink(IConfiguration configuration, LoggerConfiguration loggerConfiguration)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            loggerConfiguration.WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Warning);
+            return;
+        }
+
+        var source = configuration["Logging:EventLog:Source"]
+            ?? Environment.GetEnvironmentVariable("CRM_EVENT_SOURCE")
+            ?? "CRMAdapter.Api";
+        var logName = configuration["Logging:EventLog:LogName"]
+            ?? Environment.GetEnvironmentVariable("CRM_EVENT_LOG")
+            ?? "Application";
+
+        loggerConfiguration.WriteTo.EventLog(
+            source,
+            manageEventSource: true,
+            eventLogName: logName,
+            restrictedToMinimumLevel: LogEventLevel.Information);
+    }
+
+    private static void ConfigureOnlineSink(IConfiguration configuration, LoggerConfiguration loggerConfiguration)
+    {
+        var connectionString = configuration["Logging:ApplicationInsights:ConnectionString"]
+            ?? Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+            ?? Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            loggerConfiguration.WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Warning);
+            return;
+        }
+
+        var telemetryConverter = TelemetryConverter.Traces;
+        loggerConfiguration.WriteTo.ApplicationInsights(connectionString, telemetryConverter, LogEventLevel.Information);
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/CRMAdapter/CRMAdapter.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,91 @@
+// File: CorrelationIdMiddleware.cs
+// Summary: Ensures each request has a correlation identifier for logging and telemetry enrichment.
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Serilog.Context;
+
+namespace CRMAdapter.Api.Middleware;
+
+/// <summary>
+/// Adds and propagates correlation identifiers for incoming HTTP requests.
+/// </summary>
+public sealed class CorrelationIdMiddleware
+{
+    /// <summary>
+    /// Header used to propagate correlation identifiers.
+    /// </summary>
+    public const string CorrelationHeaderName = "X-Correlation-ID";
+
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CorrelationIdMiddleware> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CorrelationIdMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">Delegate representing the next middleware in the pipeline.</param>
+    /// <param name="logger">Logger used to record diagnostic messages.</param>
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Processes the request to ensure a correlation identifier is present.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var correlationId = ResolveCorrelationId(context);
+        context.TraceIdentifier = correlationId;
+        context.Items[CorrelationHeaderName] = correlationId;
+        context.Response.Headers[CorrelationHeaderName] = correlationId;
+
+        var activity = Activity.Current ?? new Activity("CRMAdapter.Api.Request");
+        if (activity.IdFormat == ActivityIdFormat.Unknown)
+        {
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+        }
+
+        var startedActivity = false;
+        if (!activity.IsRunning)
+        {
+            activity.Start();
+            startedActivity = true;
+        }
+
+        activity.SetTag("crm.correlation_id", correlationId);
+
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        using (LogContext.PushProperty("TraceIdentifier", correlationId))
+        {
+            _logger.LogDebug("Correlation identifier assigned: {CorrelationId}.", correlationId);
+            await _next(context).ConfigureAwait(false);
+        }
+
+        if (startedActivity)
+        {
+            activity.Stop();
+        }
+    }
+
+    private static string ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(CorrelationHeaderName, out var headerValues)
+            && !string.IsNullOrWhiteSpace(headerValues))
+        {
+            return headerValues.ToString();
+        }
+
+        return Guid.NewGuid().ToString("N");
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Middleware/ExceptionMiddleware.cs
+++ b/CRMAdapter/CRMAdapter.Api/Middleware/ExceptionMiddleware.cs
@@ -1,0 +1,122 @@
+// File: ExceptionMiddleware.cs
+// Summary: Converts unhandled exceptions into RFC 7807 ProblemDetails responses with sanitized payloads.
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Middleware;
+
+/// <summary>
+/// Captures unhandled exceptions and renders standardized error responses.
+/// </summary>
+public sealed class ExceptionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionMiddleware> _logger;
+    private readonly IHostEnvironment _environment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExceptionMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next component in the pipeline.</param>
+    /// <param name="logger">Logger used to capture diagnostics.</param>
+    /// <param name="environment">Host environment to control error detail exposure.</param>
+    public ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger, IHostEnvironment environment)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+    }
+
+    /// <summary>
+    /// Invokes the middleware.
+    /// </summary>
+    /// <param name="context">HTTP context for the current request.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        try
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+        catch (CustomerNotFoundException notFound)
+        {
+            _logger.LogWarning(notFound, "Customer not found: {Message}", notFound.Message);
+            await WriteProblemAsync(context, StatusCodes.Status404NotFound, notFound.Message, notFound.ErrorCode).ConfigureAwait(false);
+        }
+        catch (InvalidAdapterRequestException invalidRequest)
+        {
+            _logger.LogInformation(invalidRequest, "Adapter validation failure: {Message}", invalidRequest.Message);
+            await WriteProblemAsync(context, StatusCodes.Status400BadRequest, invalidRequest.Message, invalidRequest.ErrorCode).ConfigureAwait(false);
+        }
+        catch (AdapterDataAccessException dataAccess)
+        {
+            _logger.LogError(dataAccess, "Adapter data access failure while executing {Operation}.", dataAccess.Operation);
+            await WriteProblemAsync(context, StatusCodes.Status503ServiceUnavailable, "The CRM backend is currently unavailable. Please retry.", dataAccess.ErrorCode).ConfigureAwait(false);
+        }
+        catch (AdapterException adapterException)
+        {
+            _logger.LogError(adapterException, "Unhandled adapter exception: {ErrorCode}", adapterException.ErrorCode);
+            await WriteProblemAsync(context, StatusCodes.Status502BadGateway, "The CRM adapter encountered an unexpected condition.", adapterException.ErrorCode).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception processing request.");
+            var detail = _environment.IsDevelopment() ? ex.Message : "An unexpected server error occurred.";
+            await WriteProblemAsync(context, StatusCodes.Status500InternalServerError, detail, "API-UNHANDLED").ConfigureAwait(false);
+        }
+    }
+
+    private async Task WriteProblemAsync(HttpContext context, int statusCode, string detail, string errorCode)
+    {
+        if (context.Response.HasStarted)
+        {
+            _logger.LogWarning("Response already started; skipping problem response for status {StatusCode}.", statusCode);
+            return;
+        }
+
+        context.Response.Clear();
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/problem+json";
+
+        var correlationId = GetCorrelationId(context);
+        var problem = new ProblemDetails
+        {
+            Title = ReasonPhrases.GetReasonPhrase(statusCode) ?? "Unexpected error",
+            Detail = detail,
+            Status = statusCode,
+            Instance = context.Request.Path,
+            Type = "https://datatracker.ietf.org/doc/html/rfc7807",
+        };
+
+        problem.Extensions["errorCode"] = errorCode;
+        if (!string.IsNullOrWhiteSpace(correlationId))
+        {
+            problem.Extensions["correlationId"] = correlationId;
+        }
+
+        await context.Response.WriteAsJsonAsync(problem).ConfigureAwait(false);
+    }
+
+    private static string? GetCorrelationId(HttpContext context)
+    {
+        if (context.Items.TryGetValue(CorrelationIdMiddleware.CorrelationHeaderName, out var value)
+            && value is string correlationId)
+        {
+            return correlationId;
+        }
+
+        return context.TraceIdentifier;
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Program.cs
+++ b/CRMAdapter/CRMAdapter.Api/Program.cs
@@ -1,0 +1,23 @@
+// File: Program.cs
+// Summary: Entry point for the CRMAdapter.Api application that wires up the minimal API pipeline.
+using CRMAdapter.Api.Logging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+SerilogConfig.Configure(builder);
+
+var startup = new CRMAdapter.Api.Startup(builder.Configuration, builder.Environment);
+startup.ConfigureServices(builder.Services);
+
+var app = builder.Build();
+
+startup.Configure(app);
+
+app.Run();
+
+/// <summary>
+/// Marker class used by integration tests to reference the application entry point.
+/// </summary>
+public partial class Program
+{
+}

--- a/CRMAdapter/CRMAdapter.Api/SampleAuthConfig.md
+++ b/CRMAdapter/CRMAdapter.Api/SampleAuthConfig.md
@@ -1,0 +1,63 @@
+# Sample JWT Issuance for CRMAdapter.Api
+
+The API enforces JWT bearer authentication with role-based authorization. The defaults in
+`Config/appsettings.json` expect the following token properties:
+
+- **Issuer**: `crm-adapter-api`
+- **Audience**: `crm-clients`
+- **Signing key**: `SuperSecureSigningKeyForCanonicalAdapter123!`
+- **Roles**: `Admin`, `Manager`, `Clerk`, `Tech`
+
+## Generating a developer token
+
+The snippet below produces a short-lived JWT that satisfies the default configuration.
+It uses the same symmetric signing key shipped with the sample configuration so the token
+can be evaluated locally without standing up an identity provider.
+
+```powershell
+# Requires PowerShell 7+
+$issuer = "crm-adapter-api"
+$audience = "crm-clients"
+$key = "SuperSecureSigningKeyForCanonicalAdapter123!"
+$expires = [DateTimeOffset]::UtcNow.AddHours(4)
+$claims = @(
+    New-Object System.Security.Claims.Claim([System.Security.Claims.ClaimTypes]::NameIdentifier, [guid]::NewGuid().ToString()),
+    New-Object System.Security.Claims.Claim([System.Security.Claims.ClaimTypes]::Role, "Admin"),
+    New-Object System.Security.Claims.Claim("scope", "crm.api")
+)
+
+$credentials = New-Object Microsoft.IdentityModel.Tokens.SigningCredentials(
+    (New-Object Microsoft.IdentityModel.Tokens.SymmetricSecurityKey([System.Text.Encoding]::UTF8.GetBytes($key))),
+    [Microsoft.IdentityModel.Tokens.SecurityAlgorithms]::HmacSha256
+)
+
+$token = New-Object System.IdentityModel.Tokens.Jwt.JwtSecurityToken(
+    $issuer,
+    $audience,
+    $claims,
+    [DateTime]::UtcNow,
+    $expires.UtcDateTime,
+    $credentials
+)
+
+$handler = New-Object System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler
+$handler.WriteToken($token)
+```
+
+## Mapping roles to policies
+
+The table below shows how API policies map to roles. Ensure the JWT contains one of the
+listed roles to access the corresponding endpoint.
+
+| Policy | Allowed roles | Endpoints |
+| --- | --- | --- |
+| `Policies.Customers.Read` | Admin, Manager, Clerk | `GET /customers/{id}` |
+| `Policies.Customers.Search` | Admin, Manager, Clerk | `POST /customers/search` |
+| `Policies.Vehicles.Read` | Admin, Manager, Tech | `GET /vehicles/{id}` |
+| `Policies.Invoices.Read` | Admin, Manager, Clerk | `GET /invoices/{id}` |
+| `Policies.Appointments.Read` | Admin, Manager, Clerk, Tech | `GET /appointments/{id}` |
+
+> **Production guidance:** configure `Jwt` settings to match your identity provider. Point
+> `Authority` at your OpenID Connect discovery endpoint, store the symmetric key in a
+> hardware security module or secret manager, and assign roles through your identity
+> system rather than embedding them manually.

--- a/CRMAdapter/CRMAdapter.Api/Security/AuthPolicies.cs
+++ b/CRMAdapter/CRMAdapter.Api/Security/AuthPolicies.cs
@@ -1,0 +1,81 @@
+// File: AuthPolicies.cs
+// Summary: Centralizes role-based access control policy definitions for the API.
+using System;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CRMAdapter.Api.Security;
+
+/// <summary>
+/// Defines authorization policy names and role assignments used by the API.
+/// </summary>
+public static class AuthPolicies
+{
+    /// <summary>
+    /// Policy requiring roles that can read customer information.
+    /// </summary>
+    public const string CustomerRead = "Policies.Customers.Read";
+
+    /// <summary>
+    /// Policy requiring roles that can execute customer search operations.
+    /// </summary>
+    public const string CustomerSearch = "Policies.Customers.Search";
+
+    /// <summary>
+    /// Policy requiring roles that can read vehicle information.
+    /// </summary>
+    public const string VehicleRead = "Policies.Vehicles.Read";
+
+    /// <summary>
+    /// Policy requiring roles that can read invoice information.
+    /// </summary>
+    public const string InvoiceRead = "Policies.Invoices.Read";
+
+    /// <summary>
+    /// Policy requiring roles that can read appointment information.
+    /// </summary>
+    public const string AppointmentRead = "Policies.Appointments.Read";
+
+    /// <summary>
+    /// Registers authorization policies with the supplied options.
+    /// </summary>
+    /// <param name="options">Authorization options to populate.</param>
+    public static void Configure(AuthorizationOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        options.AddPolicy(CustomerRead, policy => policy.RequireRole(Roles.Admin, Roles.Manager, Roles.Clerk));
+        options.AddPolicy(CustomerSearch, policy => policy.RequireRole(Roles.Admin, Roles.Manager, Roles.Clerk));
+        options.AddPolicy(VehicleRead, policy => policy.RequireRole(Roles.Admin, Roles.Manager, Roles.Tech));
+        options.AddPolicy(InvoiceRead, policy => policy.RequireRole(Roles.Admin, Roles.Manager, Roles.Clerk));
+        options.AddPolicy(AppointmentRead, policy => policy.RequireRole(Roles.Admin, Roles.Manager, Roles.Tech, Roles.Clerk));
+    }
+
+    /// <summary>
+    /// Declares canonical role names used by the API policies.
+    /// </summary>
+    public static class Roles
+    {
+        /// <summary>
+        /// Gets the administrator role name.
+        /// </summary>
+        public const string Admin = "Admin";
+
+        /// <summary>
+        /// Gets the manager role name.
+        /// </summary>
+        public const string Manager = "Manager";
+
+        /// <summary>
+        /// Gets the clerk role name.
+        /// </summary>
+        public const string Clerk = "Clerk";
+
+        /// <summary>
+        /// Gets the technician role name.
+        /// </summary>
+        public const string Tech = "Tech";
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Security/JwtConfig.cs
+++ b/CRMAdapter/CRMAdapter.Api/Security/JwtConfig.cs
@@ -1,0 +1,143 @@
+// File: JwtConfig.cs
+// Summary: Binds JWT authentication configuration and applies it to JwtBearerOptions.
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace CRMAdapter.Api.Security;
+
+/// <summary>
+/// Represents configurable settings for JWT bearer authentication.
+/// </summary>
+public sealed class JwtConfig
+{
+    /// <summary>
+    /// Name of the configuration section that holds JWT settings.
+    /// </summary>
+    public const string SectionName = "Jwt";
+
+    /// <summary>
+    /// Gets or sets the issuer expected on incoming tokens.
+    /// </summary>
+    public string? Issuer { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional acceptable issuers.
+    /// </summary>
+    public string[]? ValidIssuers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audience expected on incoming tokens.
+    /// </summary>
+    public string? Audience { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional acceptable audiences.
+    /// </summary>
+    public string[]? ValidAudiences { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OpenID Connect authority (metadata endpoint).
+    /// </summary>
+    public string? Authority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symmetric signing key used for local token validation scenarios.
+    /// </summary>
+    public string? SigningKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the token issuer should be validated.
+    /// </summary>
+    public bool ValidateIssuer { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the token audience should be validated.
+    /// </summary>
+    public bool ValidateAudience { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the token lifetime should be validated.
+    /// </summary>
+    public bool ValidateLifetime { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the signing key should be validated.
+    /// </summary>
+    public bool ValidateIssuerSigningKey { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HTTPS metadata is required.
+    /// </summary>
+    public bool RequireHttpsMetadata { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the allowed clock skew for token expiration validation.
+    /// </summary>
+    public TimeSpan ClockSkew { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Applies the configuration to the supplied <see cref="JwtBearerOptions"/> instance.
+    /// </summary>
+    /// <param name="options">Options instance to configure.</param>
+    public void Configure(JwtBearerOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        options.RequireHttpsMetadata = RequireHttpsMetadata;
+        options.SaveToken = true;
+
+        if (!string.IsNullOrWhiteSpace(Authority))
+        {
+            options.Authority = Authority;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Audience))
+        {
+            options.Audience = Audience;
+        }
+
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = ValidateIssuer,
+            ValidateAudience = ValidateAudience,
+            ValidateLifetime = ValidateLifetime,
+            ValidateIssuerSigningKey = ValidateIssuerSigningKey,
+            ClockSkew = ClockSkew,
+            RequireSignedTokens = ValidateIssuerSigningKey,
+            RoleClaimType = ClaimTypes.Role,
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+        };
+
+        if (!string.IsNullOrWhiteSpace(Issuer))
+        {
+            options.TokenValidationParameters.ValidIssuer = Issuer;
+        }
+
+        if (ValidIssuers is { Length: > 0 })
+        {
+            options.TokenValidationParameters.ValidIssuers = ValidIssuers;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Audience))
+        {
+            options.TokenValidationParameters.ValidAudience = Audience;
+        }
+
+        if (ValidAudiences is { Length: > 0 })
+        {
+            options.TokenValidationParameters.ValidAudiences = ValidAudiences;
+        }
+
+        if (!string.IsNullOrWhiteSpace(SigningKey))
+        {
+            options.TokenValidationParameters.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SigningKey));
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Startup.cs
+++ b/CRMAdapter/CRMAdapter.Api/Startup.cs
@@ -1,0 +1,258 @@
+// File: Startup.cs
+// Summary: Configures services and the middleware pipeline for the CRMAdapter.Api minimal API host.
+using System;
+using System.Data.Common;
+using System.IO;
+using System.IdentityModel.Tokens.Jwt;
+using CRMAdapter.Api.Endpoints;
+using CRMAdapter.Api.Middleware;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonInfrastructure;
+using CRMAdapter.Factory;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+
+namespace CRMAdapter.Api;
+
+/// <summary>
+/// Configures dependency injection, security, adapters, and middleware for the API host.
+/// </summary>
+public sealed class Startup
+{
+    private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Startup"/> class.
+    /// </summary>
+    /// <param name="configuration">Configuration root used to populate options.</param>
+    /// <param name="environment">Environment metadata for conditional behavior.</param>
+    public Startup(IConfiguration configuration, IHostEnvironment environment)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+    }
+
+    /// <summary>
+    /// Registers services required by the API.
+    /// </summary>
+    /// <param name="services">Service collection to populate.</param>
+    public void ConfigureServices(IServiceCollection services)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        services.AddOptions();
+        services.AddHttpContextAccessor();
+        services.Configure<JwtConfig>(_configuration.GetSection(JwtConfig.SectionName));
+
+        var jwtConfig = _configuration.GetSection(JwtConfig.SectionName).Get<JwtConfig>() ?? new JwtConfig();
+        services.AddSingleton(jwtConfig);
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options => jwtConfig.Configure(options));
+
+        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+        services.AddAuthorization(options => AuthPolicies.Configure(options));
+        services.AddProblemDetails();
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(ConfigureSwagger);
+
+        RegisterAdapterBundle(services);
+
+        services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().CustomerAdapter);
+        services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().VehicleAdapter);
+        services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().InvoiceAdapter);
+        services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().AppointmentAdapter);
+    }
+
+    /// <summary>
+    /// Wires middleware and endpoint mappings into the pipeline.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    public void Configure(WebApplication app)
+    {
+        if (app is null)
+        {
+            throw new ArgumentNullException(nameof(app));
+        }
+
+        app.UseMiddleware<CorrelationIdMiddleware>();
+        app.UseMiddleware<ExceptionMiddleware>();
+        app.UseSerilogRequestLogging();
+
+        if (_environment.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        app.UseSwagger();
+        app.UseSwaggerUI(options =>
+        {
+            options.SwaggerEndpoint("/swagger/v1/swagger.json", "CRM Adapter API v1");
+            options.DisplayRequestDuration();
+        });
+
+        app.MapCustomersEndpoints();
+        app.MapVehiclesEndpoints();
+        app.MapInvoicesEndpoints();
+        app.MapAppointmentsEndpoints();
+    }
+
+    private void ConfigureSwagger(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions options)
+    {
+        var info = new OpenApiInfo
+        {
+            Title = "CRM Adapter API",
+            Version = "v1",
+            Description = "Canonical CRM endpoints backed by adapter abstractions.",
+        };
+        options.SwaggerDoc("v1", info);
+
+        var xmlPath = Path.Combine(AppContext.BaseDirectory, "Docs", "openapi.xml");
+        if (File.Exists(xmlPath))
+        {
+            options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+        }
+
+        var securityScheme = new OpenApiSecurityScheme
+        {
+            Description = "JWT Authorization header using the Bearer scheme.",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.Http,
+            Scheme = "bearer",
+            BearerFormat = "JWT",
+            Reference = new OpenApiReference
+            {
+                Type = ReferenceType.SecurityScheme,
+                Id = "Bearer",
+            },
+        };
+
+        options.AddSecurityDefinition("Bearer", securityScheme);
+        options.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            { securityScheme, Array.Empty<string>() },
+        });
+    }
+
+    private void RegisterAdapterBundle(IServiceCollection services)
+    {
+        services.AddSingleton(provider =>
+        {
+            var backend = ResolveBackend();
+            var connectionFactory = CreateConnectionFactory(backend);
+            var mappingPath = ResolveMappingPath(backend);
+            var factoryOptions = BuildAdapterFactoryOptions(backend);
+            return AdapterFactory.Create(backend, connectionFactory, mappingPath, factoryOptions);
+        });
+    }
+
+    private AdapterFactoryOptions BuildAdapterFactoryOptions(string backend)
+    {
+        var maxConcurrency = _configuration.GetValue<int?>("CRM:Adapters:MaxConcurrency") ?? 16;
+        var options = AdapterFactoryOptions.SecureDefaults(null, maxConcurrency);
+        options.Logger = ResolveAdapterLogger(backend);
+        return options;
+    }
+
+    private IAdapterLogger ResolveAdapterLogger(string backend)
+    {
+        var normalizedBackend = backend.Trim().ToUpperInvariant();
+        if (string.Equals(normalizedBackend, "VAST_ONLINE", StringComparison.Ordinal))
+        {
+            var connectionString = _configuration["Logging:ApplicationInsights:ConnectionString"]
+                ?? Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+                ?? Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return NullAdapterLogger.Instance;
+            }
+
+            var roleName = _configuration["Logging:ApplicationInsights:RoleName"]
+                ?? Environment.GetEnvironmentVariable("CRM_APPINSIGHTS_ROLE");
+            return AdapterLoggerFactory.CreateOnlineLogger(connectionString!, roleName);
+        }
+
+        var source = _configuration["Logging:EventLog:Source"]
+            ?? Environment.GetEnvironmentVariable("CRM_EVENT_SOURCE")
+            ?? "CRMAdapter.Api";
+        var logName = _configuration["Logging:EventLog:LogName"]
+            ?? Environment.GetEnvironmentVariable("CRM_EVENT_LOG")
+            ?? "Application";
+        return AdapterLoggerFactory.CreateDesktopLogger(source, logName);
+    }
+
+    private Func<DbConnection> CreateConnectionFactory(string backend)
+    {
+        var connectionString = ResolveConnectionString(backend);
+        return () => new SqlConnection(connectionString);
+    }
+
+    private string ResolveConnectionString(string backend)
+    {
+        var environmentOverride = Environment.GetEnvironmentVariable("CRM_SQL_CONNECTION");
+        if (!string.IsNullOrWhiteSpace(environmentOverride))
+        {
+            return environmentOverride!;
+        }
+
+        var connectionName = string.Equals(backend.Trim(), "VAST_ONLINE", StringComparison.OrdinalIgnoreCase)
+            ? "VastOnline"
+            : "VastDesktop";
+        var connectionString = _configuration.GetConnectionString(connectionName);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException($"Connection string '{connectionName}' is not configured.");
+        }
+
+        return connectionString!;
+    }
+
+    private string ResolveMappingPath(string backend)
+    {
+        var environmentOverride = Environment.GetEnvironmentVariable("CRM_MAPPING_PATH");
+        if (!string.IsNullOrWhiteSpace(environmentOverride))
+        {
+            return Path.GetFullPath(environmentOverride!);
+        }
+
+        var mappingKey = $"CRM:Mapping:{backend.Trim().ToUpperInvariant()}";
+        var mappingPath = _configuration[mappingKey];
+        if (string.IsNullOrWhiteSpace(mappingPath))
+        {
+            throw new InvalidOperationException($"Mapping path for backend '{backend}' is not configured.");
+        }
+
+        var combined = Path.Combine(AppContext.BaseDirectory, mappingPath!);
+        return Path.GetFullPath(combined);
+    }
+
+    private string ResolveBackend()
+    {
+        var backendFromConfig = _configuration["CRM:Backend"];
+        if (!string.IsNullOrWhiteSpace(backendFromConfig))
+        {
+            return backendFromConfig!;
+        }
+
+        var backendFromEnvironment = Environment.GetEnvironmentVariable("CRM_BACKEND");
+        return string.IsNullOrWhiteSpace(backendFromEnvironment) ? "VAST_DESKTOP" : backendFromEnvironment!;
+    }
+}

--- a/CRMAdapter/CRMAdapter.sln
+++ b/CRMAdapter/CRMAdapter.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Core", "CRMAdapt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Tests", "Tests\CRMAdapter.Tests.csproj", "{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Api", "CRMAdapter.Api\CRMAdapter.Api.csproj", "{4DFEF50D-CE19-458A-9D45-73DF04857F02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,8 +23,12 @@ Global
 		{677142B4-CBA2-480B-9467-D92D9F241B37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{677142B4-CBA2-480B-9467-D92D9F241B37}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/CRMAdapter/Tests/CRMAdapter.Tests.csproj
+++ b/CRMAdapter/Tests/CRMAdapter.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../CRMAdapter.Core/CRMAdapter.Core.csproj" />
+    <ProjectReference Include="../CRMAdapter.Api/CRMAdapter.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,6 +40,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Gitleaks" Version="8.18.2" PrivateAssets="all" Condition="'0' == '1'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Polly" Version="8.4.0" />

--- a/CRMAdapter/Tests/IntegrationTests/Api_CustomerEndpointTests.cs
+++ b/CRMAdapter/Tests/IntegrationTests/Api_CustomerEndpointTests.cs
@@ -1,0 +1,221 @@
+// File: Api_CustomerEndpointTests.cs
+// Summary: Integration test validating the canonical API surface over stubbed adapters.
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Security;
+using CRMAdapter.CommonContracts;
+using CRMAdapter.CommonDomain;
+using CRMAdapter.Factory;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Tokens;
+
+namespace CRMAdapter.Tests.IntegrationTests;
+
+/// <summary>
+/// Exercises the hosted API surface by issuing HTTP requests against a test server.
+/// </summary>
+public sealed class Api_CustomerEndpointTests : IAsyncLifetime
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private HttpClient? _client;
+    private Guid _customerId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Api_CustomerEndpointTests"/> class.
+    /// </summary>
+    public Api_CustomerEndpointTests()
+    {
+        _customerId = Guid.NewGuid();
+        var customer = CreateCustomer(_customerId);
+        var bundle = new AdapterBundle(
+            new TestCustomerAdapter(customer),
+            new TestVehicleAdapter(customer),
+            new TestInvoiceAdapter(customer),
+            new TestAppointmentAdapter(customer));
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<AdapterBundle>();
+                services.AddSingleton(bundle);
+            });
+        });
+    }
+
+    /// <inheritdoc />
+    public Task InitializeAsync()
+    {
+        _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GenerateToken(AuthPolicies.Roles.Admin));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Verifies that the canonical customer endpoint returns the adapter projection.
+    /// </summary>
+    [Fact]
+    public async Task GetCustomerById_ReturnsCanonicalCustomer()
+    {
+        if (_client is null)
+        {
+            throw new InvalidOperationException("Test client is not initialized.");
+        }
+
+        var response = await _client.GetAsync($"/customers/{_customerId}").ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<Customer>().ConfigureAwait(false);
+        payload.Should().NotBeNull();
+        payload!.Id.Should().Be(_customerId);
+        payload.DisplayName.Should().Be("Ada Lovelace");
+        payload.PostalAddress.City.Should().Be("London");
+    }
+
+    private static string GenerateToken(string role)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SuperSecureSigningKeyForCanonicalAdapter123!"));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.CreateJwtSecurityToken(
+            issuer: "crm-adapter-api",
+            audience: "crm-clients",
+            subject: new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+                new Claim(ClaimTypes.Role, role),
+            }),
+            notBefore: DateTime.UtcNow.AddMinutes(-1),
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: credentials);
+        return handler.WriteToken(token);
+    }
+
+    private static Customer CreateCustomer(Guid id)
+    {
+        var address = new PostalAddress("123 Royal St", null, "London", "London", "SW1A", "GB");
+        var vehicleReference = new VehicleReference(Guid.NewGuid(), "1FTSW21R08EB53158");
+        return new Customer(
+            id,
+            "Ada Lovelace",
+            "ada.lovelace@example.com",
+            "+441234567890",
+            address,
+            new[] { vehicleReference });
+    }
+
+    private sealed class TestCustomerAdapter : ICustomerAdapter
+    {
+        private readonly Customer _customer;
+
+        public TestCustomerAdapter(Customer customer)
+        {
+            _customer = customer;
+        }
+
+        public Task<Customer?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<Customer?>(id == _customer.Id ? _customer : null);
+        }
+
+        public Task<IReadOnlyCollection<Customer>> SearchByNameAsync(string nameQuery, int maxResults, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyCollection<Customer>>(new[] { _customer });
+        }
+
+        public Task<IReadOnlyCollection<Customer>> GetRecentCustomersAsync(int maxResults, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyCollection<Customer>>(new[] { _customer });
+        }
+    }
+
+    private sealed class TestVehicleAdapter : IVehicleAdapter
+    {
+        private readonly Customer _customer;
+
+        public TestVehicleAdapter(Customer customer)
+        {
+            _customer = customer;
+        }
+
+        public Task<Vehicle?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var reference = _customer.Vehicles.First();
+            var vehicle = new Vehicle(reference.Id, reference.Vin, "Ford", "F-150", 2023, 12000, _customer.Id);
+            return Task.FromResult<Vehicle?>(id == reference.Id ? vehicle : null);
+        }
+    }
+
+    private sealed class TestInvoiceAdapter : IInvoiceAdapter
+    {
+        private readonly Customer _customer;
+
+        public TestInvoiceAdapter(Customer customer)
+        {
+            _customer = customer;
+        }
+
+        public Task<Invoice?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var invoice = new Invoice(id, _customer.Id, _customer.Vehicles.First().Id, "INV-1001", DateTime.UtcNow, 199.99m, "Paid", new[]
+            {
+                new InvoiceLine("Oil Change", 1, 99.99m, 8.25m),
+            });
+            return Task.FromResult<Invoice?>(invoice);
+        }
+
+        public Task<IReadOnlyCollection<Invoice>> GetByCustomerAsync(Guid customerId, int maxResults, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyCollection<Invoice>>(Array.Empty<Invoice>());
+        }
+    }
+
+    private sealed class TestAppointmentAdapter : IAppointmentAdapter
+    {
+        private readonly Customer _customer;
+
+        public TestAppointmentAdapter(Customer customer)
+        {
+            _customer = customer;
+        }
+
+        public Task<Appointment?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var appointment = new Appointment(
+                id,
+                _customer.Id,
+                _customer.Vehicles.First().Id,
+                DateTime.UtcNow.AddDays(1),
+                DateTime.UtcNow.AddDays(1).AddHours(1),
+                "Advisor",
+                "Scheduled",
+                "Service Bay 1");
+            return Task.FromResult<Appointment?>(appointment);
+        }
+
+        public Task<IReadOnlyCollection<Appointment>> GetByDateAsync(DateTime date, int maxResults, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyCollection<Appointment>>(Array.Empty<Appointment>());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the CRMAdapter.Api minimal API project that exposes canonical customer, vehicle, invoice, and appointment endpoints secured with JWT and role policies
- configure Serilog logging, correlation IDs, exception handling, Swagger/OpenAPI, and environment-driven adapter selection plus sample auth configuration
- add an integration test that exercises the customer endpoint through an adapter bundle

## Testing
- dotnet test CRMAdapter.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e8f41e20832fa670a6b290e5316b