### PR TITLE
Harden authentication and telemetry handling

### DIFF
--- a/CRMAdapter/CRMAdapter.Api/Config/appsettings.Development.json
+++ b/CRMAdapter/CRMAdapter.Api/Config/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "CRM": {
     "Backend": "VAST_ONLINE"
+  },
+  "Jwt": {
+    "RequireHttpsMetadata": false
   }
 }

--- a/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
+++ b/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
@@ -15,8 +15,8 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "VastDesktop": "Server=localhost;Database=VastDesktop;Trusted_Connection=True;Encrypt=False;",
-    "VastOnline": "Server=localhost;Database=VastOnline;Trusted_Connection=True;Encrypt=False;"
+    "VastDesktop": "Server=localhost;Database=VastDesktop;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=False;",
+    "VastOnline": "Server=localhost;Database=VastOnline;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=False;"
   },
   "CRM": {
     "Backend": "VAST_DESKTOP",
@@ -31,8 +31,7 @@
   "Jwt": {
     "Issuer": "crm-adapter-api",
     "Audience": "crm-clients",
-    "SigningKey": "SuperSecureSigningKeyForCanonicalAdapter123!",
-    "RequireHttpsMetadata": false,
+    "RequireHttpsMetadata": true,
     "ClockSkew": "00:05:00"
   }
 }

--- a/CRMAdapter/CRMAdapter.Api/Endpoints/CustomersEndpoint.cs
+++ b/CRMAdapter/CRMAdapter.Api/Endpoints/CustomersEndpoint.cs
@@ -118,7 +118,7 @@ public static class CustomersEndpoint
         var normalizedMax = Math.Clamp(request.MaxResults ?? DefaultMaxResults, 1, MaxAllowedResults);
         var normalizedQuery = request.Query.Trim();
         var logger = loggerFactory.CreateLogger(typeof(CustomersEndpoint));
-        logger.LogInformation("Executing customer search for '{Query}' with limit {Limit}.", normalizedQuery, normalizedMax);
+        logger.LogInformation("Executing customer search with limit {Limit}.", normalizedMax);
 
         var results = await adapter.SearchByNameAsync(normalizedQuery, normalizedMax, cancellationToken).ConfigureAwait(false);
         return TypedResults.Ok(results);

--- a/CRMAdapter/CRMAdapter.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/CRMAdapter/CRMAdapter.Api/Middleware/CorrelationIdMiddleware.cs
@@ -80,10 +80,13 @@ public sealed class CorrelationIdMiddleware
 
     private static string ResolveCorrelationId(HttpContext context)
     {
-        if (context.Request.Headers.TryGetValue(CorrelationHeaderName, out var headerValues)
-            && !string.IsNullOrWhiteSpace(headerValues))
+        if (context.Request.Headers.TryGetValue(CorrelationHeaderName, out var headerValues))
         {
-            return headerValues.ToString();
+            var candidate = headerValues.ToString().Trim();
+            if (Guid.TryParse(candidate, out var parsed))
+            {
+                return parsed.ToString("N");
+            }
         }
 
         return Guid.NewGuid().ToString("N");

--- a/CRMAdapter/CRMAdapter.Api/SampleAuthConfig.md
+++ b/CRMAdapter/CRMAdapter.Api/SampleAuthConfig.md
@@ -5,20 +5,23 @@ The API enforces JWT bearer authentication with role-based authorization. The de
 
 - **Issuer**: `crm-adapter-api`
 - **Audience**: `crm-clients`
-- **Signing key**: `SuperSecureSigningKeyForCanonicalAdapter123!`
+- **Signing key**: *(Provide via `JWT_SIGNING_KEY` environment variable or secret manager; not stored in source control.)*
 - **Roles**: `Admin`, `Manager`, `Clerk`, `Tech`
 
 ## Generating a developer token
 
 The snippet below produces a short-lived JWT that satisfies the default configuration.
-It uses the same symmetric signing key shipped with the sample configuration so the token
-can be evaluated locally without standing up an identity provider.
+It expects the signing key to be supplied at runtime—either export `JWT_SIGNING_KEY`
+or load the value from your preferred secret manager before executing the script.
 
 ```powershell
 # Requires PowerShell 7+
 $issuer = "crm-adapter-api"
 $audience = "crm-clients"
-$key = "SuperSecureSigningKeyForCanonicalAdapter123!"
+$key = $env:JWT_SIGNING_KEY
+if (-not $key) {
+    throw "JWT_SIGNING_KEY environment variable is not set."
+}
 $expires = [DateTimeOffset]::UtcNow.AddHours(4)
 $claims = @(
     New-Object System.Security.Claims.Claim([System.Security.Claims.ClaimTypes]::NameIdentifier, [guid]::NewGuid().ToString()),


### PR DESCRIPTION
## Summary
- remove the embedded JWT signing key, enforce secret-sourced credentials, and require HTTPS metadata outside development
- enable SQL encryption by default and scrub customer search telemetry of raw queries
- validate correlation identifiers, update auth documentation, and supply the signing key to integration tests via configuration

## Testing
- dotnet test *(fails: NETSDK1022 duplicate Content items and CS0051 accessibility errors in existing solution)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ef7b7568832f9eb00e7681120dae