### PR TITLE
Replace binary favicon with SVG asset

### DIFF
--- a/CRMAdapter/CRMAdapter.UI/App.razor
+++ b/CRMAdapter/CRMAdapter.UI/App.razor
@@ -1,0 +1,62 @@
+@* App.razor: Establishes the authenticated routing pipeline, global MudBlazor providers, and navigation fallbacks. *@
+@inject AppThemeState ThemeState
+@inject CorrelationContext CorrelationContext
+@implements IDisposable
+
+<CascadingAuthenticationState>
+    <MudThemeProvider Theme="@ThemeState.ActiveTheme" IsDarkMode="@ThemeState.IsDarkMode">
+        <MudSnackbarProvider Position="SnackbarPosition.TopCenter" MaxDisplayedSnackbars="4" SnackbarConfiguration="@ThemeState.SnackbarConfiguration">
+            <MudDialogProvider />
+            <MudPopoverProvider>
+            <Router AppAssembly="@typeof(App).Assembly" OnNavigateAsync="HandleNavigationAsync">
+                <Found Context="routeData">
+                    <ErrorBoundary>
+                        <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                            <Authorizing>
+                                <MudProgressCircular Indeterminate="true" Class="pa-6" Size="Size.Large" />
+                            </Authorizing>
+                            <NotAuthorized>
+                                <LayoutView Layout="@typeof(MainLayout)">
+                                    <MudPaper Elevation="0" Class="pa-6 ma-auto max-w-xl">
+                                        <MudText Typo="Typo.h5" Class="mb-2">Access restricted</MudText>
+                                        <MudText>You do not have the required permissions for this workspace. Contact your administrator if you believe this is an error.</MudText>
+                                    </MudPaper>
+                                </LayoutView>
+                            </NotAuthorized>
+                        </AuthorizeRouteView>
+                    </ErrorBoundary>
+                    <FocusOnNavigate RouteData="@routeData" Selector="#main-content" />
+                </Found>
+                <NotFound>
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <MudPaper Elevation="0" Class="pa-6 ma-auto max-w-xl">
+                            <MudText Typo="Typo.h5" Class="mb-2">We could not find that workspace</MudText>
+                            <MudText>Double-check the URL or select a module from the navigation menu to continue.</MudText>
+                        </MudPaper>
+                    </LayoutView>
+                </NotFound>
+            </Router>
+            </MudPopoverProvider>
+        </MudSnackbarProvider>
+</MudThemeProvider>
+</CascadingAuthenticationState>
+
+@code {
+    protected override void OnInitialized()
+    {
+        ThemeState.OnChange += OnThemeChanged;
+    }
+
+    private async Task HandleNavigationAsync(Microsoft.AspNetCore.Components.Routing.NavigationContext context)
+    {
+        CorrelationContext.Refresh();
+        await Task.CompletedTask;
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeState.OnChange -= OnThemeChanged;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Auth/AuthStateProvider.cs
+++ b/CRMAdapter/CRMAdapter.UI/Auth/AuthStateProvider.cs
@@ -1,0 +1,136 @@
+// AuthStateProvider.cs: Supplies Blazor with JWT-backed authentication state and manages secure token storage.
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Auth.Contracts;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.UI.Auth;
+
+public sealed class AuthStateProvider : AuthenticationStateProvider
+{
+    private const string AccessTokenKey = "crm-adapter-access-token";
+    private const string RefreshTokenKey = "crm-adapter-refresh-token";
+    private const string ExpiryKey = "crm-adapter-token-expiry";
+
+    private readonly ProtectedSessionStorage _sessionStorage;
+    private readonly JwtAuthProvider _jwtAuthProvider;
+    private readonly ILogger<AuthStateProvider> _logger;
+    private readonly JwtSecurityTokenHandler _tokenHandler = new();
+    private ClaimsPrincipal _currentUser = new(new ClaimsIdentity());
+
+    public AuthStateProvider(ProtectedSessionStorage sessionStorage, JwtAuthProvider jwtAuthProvider, ILogger<AuthStateProvider> logger)
+    {
+        _sessionStorage = sessionStorage;
+        _jwtAuthProvider = jwtAuthProvider;
+        _logger = logger;
+    }
+
+    public ClaimsPrincipal CurrentUser => _currentUser;
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var accessToken = await ReadTokenAsync();
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+            return new AuthenticationState(_currentUser);
+        }
+
+        var expiry = await ReadExpiryAsync();
+        if (IsExpired(expiry))
+        {
+            var refreshToken = await ReadRefreshTokenAsync();
+            if (!string.IsNullOrWhiteSpace(refreshToken))
+            {
+                try
+                {
+                    var refreshedSession = await _jwtAuthProvider.RefreshAsync(refreshToken);
+                    await StoreSessionAsync(refreshedSession);
+                    accessToken = refreshedSession.AccessToken;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Token refresh failed; clearing authentication state.");
+                    await ClearAsync();
+                    _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+                    return new AuthenticationState(_currentUser);
+                }
+            }
+            else
+            {
+                await ClearAsync();
+                _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+                return new AuthenticationState(_currentUser);
+            }
+        }
+
+        var principal = BuildPrincipal(accessToken);
+        _currentUser = principal;
+        return new AuthenticationState(principal);
+    }
+
+    public async Task PersistSessionAsync(JwtSession session)
+    {
+        await StoreSessionAsync(session);
+        var principal = BuildPrincipal(session.AccessToken);
+        _currentUser = principal;
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(principal)));
+    }
+
+    public async Task SignOutAsync()
+    {
+        await ClearAsync();
+        _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(_currentUser)));
+    }
+
+    private ClaimsPrincipal BuildPrincipal(string accessToken)
+    {
+        var token = _tokenHandler.ReadJwtToken(accessToken);
+        var identity = new ClaimsIdentity(token.Claims, authenticationType: "jwt");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private Task StoreSessionAsync(JwtSession session)
+    {
+        return Task.WhenAll(
+            _sessionStorage.SetAsync(AccessTokenKey, session.AccessToken).AsTask(),
+            _sessionStorage.SetAsync(RefreshTokenKey, session.RefreshToken).AsTask(),
+            _sessionStorage.SetAsync(ExpiryKey, session.ExpiresAt).AsTask());
+    }
+
+    private async Task<string?> ReadTokenAsync()
+    {
+        var stored = await _sessionStorage.GetAsync<string>(AccessTokenKey);
+        return stored.Success ? stored.Value : null;
+    }
+
+    private async Task<string?> ReadRefreshTokenAsync()
+    {
+        var stored = await _sessionStorage.GetAsync<string>(RefreshTokenKey);
+        return stored.Success ? stored.Value : null;
+    }
+
+    private async Task<DateTimeOffset?> ReadExpiryAsync()
+    {
+        var stored = await _sessionStorage.GetAsync<DateTimeOffset>(ExpiryKey);
+        return stored.Success ? stored.Value : null;
+    }
+
+    private static bool IsExpired(DateTimeOffset? expiry)
+    {
+        return !expiry.HasValue || expiry.Value <= DateTimeOffset.UtcNow.AddMinutes(-1);
+    }
+
+    private Task ClearAsync()
+    {
+        return Task.WhenAll(
+            _sessionStorage.DeleteAsync(AccessTokenKey).AsTask(),
+            _sessionStorage.DeleteAsync(RefreshTokenKey).AsTask(),
+            _sessionStorage.DeleteAsync(ExpiryKey).AsTask());
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Auth/Contracts/JwtSession.cs
+++ b/CRMAdapter/CRMAdapter.UI/Auth/Contracts/JwtSession.cs
@@ -1,0 +1,6 @@
+// JwtSession.cs: Captures the tokens and expiry returned from the CRM authentication API.
+using System;
+
+namespace CRMAdapter.UI.Auth.Contracts;
+
+public sealed record JwtSession(string AccessToken, string RefreshToken, DateTimeOffset ExpiresAt);

--- a/CRMAdapter/CRMAdapter.UI/Auth/JwtAuthProvider.cs
+++ b/CRMAdapter/CRMAdapter.UI/Auth/JwtAuthProvider.cs
@@ -1,0 +1,86 @@
+// JwtAuthProvider.cs: Handles secure JWT acquisition and refresh calls against the CRM API.
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Auth.Contracts;
+using CRMAdapter.UI.Infrastructure.Security;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.UI.Auth;
+
+public sealed class JwtAuthProvider
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<JwtAuthProvider> _logger;
+    private readonly IConfiguration _configuration;
+
+    public JwtAuthProvider(IHttpClientFactory httpClientFactory, ILogger<JwtAuthProvider> logger, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public async Task<JwtSession> SignInAsync(string userName, string password, CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientNames.CrmApi);
+        var request = new AuthenticationRequest(userName, password);
+
+        using var response = await client.PostAsJsonAsync(GetEndpoint("Authentication:Jwt:LoginEndpoint", "identity/login"), request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Authentication failed with status code {StatusCode}", response.StatusCode);
+            throw new AuthenticationException("Unable to authenticate with the CRM API.");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken);
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.AccessToken))
+        {
+            throw new AuthenticationException("The CRM API returned an invalid authentication payload.");
+        }
+
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(payload.ExpiresInSeconds <= 0 ? 3600 : payload.ExpiresInSeconds);
+        return new JwtSession(payload.AccessToken, payload.RefreshToken ?? string.Empty, expiresAt);
+    }
+
+    public async Task<JwtSession> RefreshAsync(string refreshToken, CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientNames.CrmApi);
+        var request = new RefreshRequest(refreshToken);
+
+        using var response = await client.PostAsJsonAsync(GetEndpoint("Authentication:Jwt:RefreshEndpoint", "identity/refresh"), request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Token refresh failed with status code {StatusCode}", response.StatusCode);
+            throw new AuthenticationException("Unable to refresh the authentication session.");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken);
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.AccessToken))
+        {
+            throw new AuthenticationException("The CRM API returned an invalid refresh payload.");
+        }
+
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(payload.ExpiresInSeconds <= 0 ? 3600 : payload.ExpiresInSeconds);
+        return new JwtSession(payload.AccessToken, payload.RefreshToken ?? refreshToken, expiresAt);
+    }
+
+    private string GetEndpoint(string configurationKey, string fallback)
+    {
+        return _configuration[configurationKey] ?? fallback;
+    }
+
+    private sealed record AuthenticationRequest(string UserName, string Password);
+
+    private sealed record RefreshRequest(string RefreshToken);
+
+    private sealed record TokenResponse(string AccessToken, string? RefreshToken, int ExpiresInSeconds);
+}

--- a/CRMAdapter/CRMAdapter.UI/Auth/RolePolicies.cs
+++ b/CRMAdapter/CRMAdapter.UI/Auth/RolePolicies.cs
@@ -1,0 +1,25 @@
+// RolePolicies.cs: Declares CRMAdapter roles and registers authorization policies for consistent enforcement.
+using System;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CRMAdapter.UI.Auth;
+
+public static class RolePolicies
+{
+    public const string Admin = "Admin";
+    public const string Manager = "Manager";
+    public const string Clerk = "Clerk";
+    public const string Tech = "Tech";
+
+    public static readonly string[] AllRoles = { Admin, Manager, Clerk, Tech };
+
+    public static void RegisterPolicies(AuthorizationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.AddPolicy(Admin, policy => policy.RequireRole(Admin));
+        options.AddPolicy(Manager, policy => policy.RequireRole(Manager, Admin));
+        options.AddPolicy(Clerk, policy => policy.RequireRole(Clerk, Manager, Admin));
+        options.AddPolicy(Tech, policy => policy.RequireRole(Tech, Manager, Admin));
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
+++ b/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
@@ -1,0 +1,17 @@
+<!-- CRMAdapter.UI.csproj: Project definition for the Blazor Server application with MudBlazor integration. -->
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);MUD0002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
+  </ItemGroup>
+
+</Project>

--- a/CRMAdapter/CRMAdapter.UI/Hosting/ApplicationHost.razor
+++ b/CRMAdapter/CRMAdapter.UI/Hosting/ApplicationHost.razor
@@ -1,0 +1,25 @@
+@* Hosting/ApplicationHost.razor: Provides the HTML host shell that bootstraps the Blazor Server app and loads global styles and scripts. *@
+<!DOCTYPE html>
+<html lang="en" data-app-shell="crm-adapter">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
+    <link rel="stylesheet" href="CRMAdapter.UI.styles.css" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <HeadOutlet />
+</head>
+
+<body class="app-shell" data-telemetry-scope="crm-adapter-ui">
+    <App />
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_framework/blazor.web.js"></script>
+</body>
+
+</html>

--- a/CRMAdapter/CRMAdapter.UI/Infrastructure/Security/HttpClientNames.cs
+++ b/CRMAdapter/CRMAdapter.UI/Infrastructure/Security/HttpClientNames.cs
@@ -1,0 +1,7 @@
+// HttpClientNames.cs: Centralizes named HttpClient identifiers for API integrations.
+namespace CRMAdapter.UI.Infrastructure.Security;
+
+public static class HttpClientNames
+{
+    public const string CrmApi = "CrmApi";
+}

--- a/CRMAdapter/CRMAdapter.UI/Infrastructure/Security/JwtClientOptions.cs
+++ b/CRMAdapter/CRMAdapter.UI/Infrastructure/Security/JwtClientOptions.cs
@@ -1,0 +1,9 @@
+// JwtClientOptions.cs: Configuration contract for JWT authority and audience metadata consumed by the client.
+namespace CRMAdapter.UI.Infrastructure.Security;
+
+public sealed class JwtClientOptions
+{
+    public string Authority { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string MetadataAddress { get; set; } = string.Empty;
+}

--- a/CRMAdapter/CRMAdapter.UI/Navigation/NavigationLink.cs
+++ b/CRMAdapter/CRMAdapter.UI/Navigation/NavigationLink.cs
@@ -1,0 +1,9 @@
+// NavigationLink.cs: Represents a routed navigation entry with role-based visibility metadata.
+namespace CRMAdapter.UI.Navigation;
+
+public sealed record NavigationLink(
+    string Title,
+    string Icon,
+    string Href,
+    string Description,
+    string[] AllowedRoles);

--- a/CRMAdapter/CRMAdapter.UI/Navigation/NavigationMenuService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Navigation/NavigationMenuService.cs
@@ -1,0 +1,39 @@
+// NavigationMenuService.cs: Supplies role-trimmed navigation items and active route utilities for the layout.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using CRMAdapter.UI.Auth;
+
+namespace CRMAdapter.UI.Navigation;
+
+public sealed class NavigationMenuService
+{
+    private static readonly IReadOnlyList<NavigationLink> Links = new List<NavigationLink>
+    {
+        new("Command Center", Icons.Material.Filled.DashboardCustomize, "/", "Executive overview with actionable KPIs.", RolePolicies.AllRoles),
+        new("Operations", Icons.Material.Filled.PrecisionManufacturing, "/operations", "Order orchestration and fulfillment visibility.", new[] { RolePolicies.Admin, RolePolicies.Manager, RolePolicies.Clerk }),
+        new("Field Service", Icons.Material.Filled.HomeRepairService, "/field-service", "Technician dispatching and status intelligence.", new[] { RolePolicies.Tech, RolePolicies.Manager }),
+        new("Data Stewardship", Icons.Material.Filled.Storage, "/data-quality", "Data quality dashboards and stewardship workflows.", new[] { RolePolicies.Admin, RolePolicies.Manager }),
+        new("Support Desk", Icons.Material.Filled.SupportAgent, "/support", "Customer support command console and SLA tracking.", new[] { RolePolicies.Admin, RolePolicies.Clerk })
+    };
+
+    public IEnumerable<NavigationLink> GetLinksForUser(ClaimsPrincipal? user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return Links.Where(l => l.AllowedRoles.Length == 0);
+        }
+
+        return Links.Where(link => link.AllowedRoles.Length == 0 || link.AllowedRoles.Any(user.IsInRole)).ToArray();
+    }
+
+    public bool IsActive(NavigationManager navigationManager, NavigationLink link)
+    {
+        var currentUri = navigationManager.Uri;
+        var absoluteLink = navigationManager.ToAbsoluteUri(link.Href).ToString();
+        return string.Equals(currentUri, absoluteLink, StringComparison.OrdinalIgnoreCase) || currentUri.StartsWith(absoluteLink, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Dashboard/Operations.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Dashboard/Operations.razor
@@ -1,0 +1,52 @@
+@* Operations.razor: Protected workspace for operations leaders to review fulfillment health. *@
+@page "/operations"
+@attribute [Authorize(Roles="Admin,Manager,Clerk")]
+
+<MudGrid Spacing="3">
+    <MudItem Xs="12">
+        <MudText Typo="Typo.h4" Class="mb-1">Operations command center</MudText>
+        <MudText Typo="Typo.body1" Class="mb-4">Track inventory risk, fulfillment throughput, and proactive escalations. Access is restricted to the operations leadership team.</MudText>
+    </MudItem>
+    <MudItem Xs="12" Md="6">
+        <MudPaper Elevation="1" Class="pa-4" role="region" aria-label="Fulfillment velocity">
+            <MudText Typo="Typo.subtitle1" Class="mb-2">Fulfillment velocity</MudText>
+            <MudChart ChartType="ChartType.Line" XAxisLabels="@(new[] { "Mon", "Tue", "Wed", "Thu", "Fri" })" Lines="@_velocity" />
+        </MudPaper>
+    </MudItem>
+    <MudItem Xs="12" Md="6">
+        <MudPaper Elevation="1" Class="pa-4" role="region" aria-label="Critical blockers">
+            <MudText Typo="Typo.subtitle1" Class="mb-2">Critical blockers</MudText>
+            <MudStack Spacing="2">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Color="Color.Warning" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Carrier outage</MudText>
+                        <MudText Typo="Typo.caption">North-east hub delays 6 hours</MudText>
+                    </MudStack>
+                </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.BuildCircle" Color="Color.Info" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Production line retool</MudText>
+                        <MudText Typo="Typo.caption">Line 4 running at 64% capacity</MudText>
+                    </MudStack>
+                </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.VerifiedUser" Color="Color.Success" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Quality hold cleared</MudText>
+                        <MudText Typo="Typo.caption">3 SKUs released</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private readonly ChartSeries[] _velocity =
+    {
+        new() { Name = "Orders shipped", Data = new double[] { 420, 460, 510, 560, 610 } },
+        new() { Name = "Orders committed", Data = new double[] { 400, 450, 495, 545, 600 } }
+    };
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Home/Landing.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Home/Landing.razor
@@ -1,0 +1,43 @@
+@* Landing.razor: Entry dashboard summarizing CRMAdapter insights and quick actions. *@
+@page "/"
+
+<MudGrid Class="landing-grid" Spacing="3">
+    <MudItem Xs="12" Md="8">
+        <MudPaper Elevation="1" Class="landing-hero" role="region" aria-label="Executive overview">
+            <MudText Typo="Typo.h3" Class="mb-2">Command your customer universe</MudText>
+            <MudText Typo="Typo.body1" Class="mb-4">Orchestrate revenue, service, and operations from a single, intelligence-driven workspace. Tailored views keep every leader aligned in real time.</MudText>
+            <MudStack Row="true" Spacing="2">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/operations">Go to operations</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="/support">View support desk</MudButton>
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+    <MudItem Xs="12" Md="4">
+        <MudPaper Elevation="1" Class="landing-kpi" role="region" aria-label="Key metrics">
+            <MudText Typo="Typo.subtitle1" Class="mb-3">Live signals</MudText>
+            <MudStack Spacing="2">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Color="Color.Success" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Pipeline health</MudText>
+                        <MudText Typo="Typo.caption">106% to quarterly target</MudText>
+                    </MudStack>
+                </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.SupportAgent" Color="Color.Info" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Open support cases</MudText>
+                        <MudText Typo="Typo.caption">18 priority tickets</MudText>
+                    </MudStack>
+                </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.Inventory2" Color="Color.Warning" Size="Size.Medium" />
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.subtitle2">Orders at risk</MudText>
+                        <MudText Typo="Typo.caption">5 orders require escalation</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+</MudGrid>

--- a/CRMAdapter/CRMAdapter.UI/Program.cs
+++ b/CRMAdapter/CRMAdapter.UI/Program.cs
@@ -1,0 +1,111 @@
+// Program.cs: Configures dependency injection, security, and MudBlazor services for the CRM Adapter UI.
+using System.Net.Http.Headers;
+using CRMAdapter.UI.Auth;
+using CRMAdapter.UI.Hosting;
+using CRMAdapter.UI.Infrastructure.Security;
+using CRMAdapter.UI.Navigation;
+using CRMAdapter.UI.Services.Diagnostics;
+using CRMAdapter.UI.Theming;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.IdentityModel.Tokens;
+using MudBlazor;
+using MudBlazor.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOptions();
+builder.Services.AddAuthorization(options => RolePolicies.RegisterPolicies(options));
+
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
+    .AddJwtBearer(options =>
+    {
+        var authority = builder.Configuration["Authentication:Jwt:Authority"];
+        var audience = builder.Configuration["Authentication:Jwt:Audience"];
+        var metadataAddress = builder.Configuration["Authentication:Jwt:MetadataAddress"];
+
+        if (!string.IsNullOrWhiteSpace(authority))
+        {
+            options.Authority = authority;
+            options.TokenValidationParameters.ValidIssuer = authority;
+            options.TokenValidationParameters.ValidateIssuer = true;
+        }
+        else
+        {
+            options.TokenValidationParameters.ValidateIssuer = false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(audience))
+        {
+            options.Audience = audience;
+            options.TokenValidationParameters.ValidAudience = audience;
+            options.TokenValidationParameters.ValidateAudience = true;
+        }
+        else
+        {
+            options.TokenValidationParameters.ValidateAudience = false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(metadataAddress))
+        {
+            options.MetadataAddress = metadataAddress;
+        }
+
+        options.RequireHttpsMetadata = true;
+        options.TokenValidationParameters.ValidateLifetime = true;
+        options.TokenValidationParameters.ClockSkew = TimeSpan.FromMinutes(1);
+        options.TokenValidationParameters.NameClaimType = "name";
+        options.TokenValidationParameters.RoleClaimType = "role";
+    });
+
+builder.Services.AddScoped<ProtectedSessionStorage>();
+builder.Services.AddScoped<AuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<AuthStateProvider>());
+builder.Services.AddScoped<JwtAuthProvider>();
+builder.Services.AddSingleton<NavigationMenuService>();
+builder.Services.AddScoped<AppThemeState>();
+builder.Services.AddScoped<CorrelationContext>();
+
+builder.Services.AddHttpClient(HttpClientNames.CrmApi, client =>
+    {
+        var baseAddress = builder.Configuration["RemoteApis:CrmApi:BaseUri"] ?? "https://localhost:7150/";
+        client.BaseAddress = new Uri(baseAddress);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    });
+
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.TopCenter;
+    config.SnackbarConfiguration.PreventDuplicates = true;
+    config.SnackbarConfiguration.NewestOnTop = true;
+    config.SnackbarConfiguration.ShowCloseIcon = true;
+    config.SnackbarConfiguration.VisibleStateDuration = 4000;
+});
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseAntiforgery();
+
+app.MapRazorComponents<ApplicationHost>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/CRMAdapter/CRMAdapter.UI/Properties/launchSettings.json
+++ b/CRMAdapter/CRMAdapter.UI/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+    "iisSettings": {
+      "windowsAuthentication": false,
+      "anonymousAuthentication": true,
+      "iisExpress": {
+        "applicationUrl": "http://localhost:47312",
+        "sslPort": 44340
+      }
+    },
+    "profiles": {
+      "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "http://localhost:5291",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+      "https": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "https://localhost:7116;http://localhost:5291",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+      "IIS Express": {
+        "commandName": "IISExpress",
+        "launchBrowser": true,
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      }
+    }
+  }

--- a/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationContext.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationContext.cs
@@ -1,0 +1,31 @@
+// CorrelationContext.cs: Generates and exposes the current request correlation identifier for diagnostics UI elements.
+using System;
+using System.Diagnostics;
+
+namespace CRMAdapter.UI.Services.Diagnostics;
+
+public sealed class CorrelationContext
+{
+    private string _currentCorrelationId = CreateCorrelationId();
+
+    public string CurrentCorrelationId => _currentCorrelationId;
+
+    public string ShortCorrelationId => _currentCorrelationId.Length > 12
+        ? _currentCorrelationId[..12].ToUpperInvariant()
+        : _currentCorrelationId.ToUpperInvariant();
+
+    public void Refresh()
+    {
+        _currentCorrelationId = CreateCorrelationId();
+    }
+
+    private static string CreateCorrelationId()
+    {
+        if (Activity.Current is { Id: { } activityId })
+        {
+            return activityId;
+        }
+
+        return $"CRM-{Guid.NewGuid():N}";
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor
@@ -1,0 +1,85 @@
+@* MainLayout.razor: Crafts the responsive shell with navigation drawer, adaptive top bar, and content surface. *@
+@inherits LayoutComponentBase
+@inject NavigationManager Navigation
+@inject AppThemeState ThemeState
+@inject ISnackbar Snackbar
+@implements IDisposable
+
+<MudLayout Class="crm-layout">
+    <MudBreakpointProvider OnBreakpointChanged="OnBreakpointChanged" Breakpoint="Breakpoint.Md" Immediate="true" />
+    <MudDrawer @bind-Open="_isDrawerOpen"
+               Variant="@_drawerVariant"
+               Elevation="1"
+               Class="crm-drawer"
+               OverlayOpacity="0.4"
+               DisableOverlay="@(_drawerVariant == DrawerVariant.Persistent)"
+               AriaLabel="Primary navigation">
+        <NavMenu OnNavigate="CloseDrawerOnMobile" />
+    </MudDrawer>
+
+    <MudMainContent>
+        <section class="crm-grid" aria-live="polite">
+            <header class="crm-topbar">
+                <TopBar OnToggleNavigation="ToggleDrawer" OnThemeToggle="ToggleTheme" OnSearch="HandleSearch" />
+            </header>
+            <main id="main-content" class="crm-content" tabindex="-1">
+                <MudPaper Class="crm-content-surface" Elevation="0">
+                    @Body
+                </MudPaper>
+            </main>
+        </section>
+    </MudMainContent>
+</MudLayout>
+
+<MudScrollToTop TopOffset="250" Icon="@Icons.Material.Filled.KeyboardArrowUp" />
+
+@code {
+    private bool _isDrawerOpen = true;
+    private DrawerVariant _drawerVariant = DrawerVariant.Persistent;
+
+    protected override void OnInitialized()
+    {
+        ThemeState.OnChange += OnThemeChanged;
+    }
+
+    private void ToggleDrawer() => _isDrawerOpen = !_isDrawerOpen;
+
+    private void ToggleTheme() => ThemeState.ToggleTheme();
+
+    private void HandleSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            Snackbar.Add("Enter a search term to explore CRM insights.", Severity.Info);
+            return;
+        }
+
+        var destination = $"/search?query={Uri.EscapeDataString(query)}";
+        Navigation.NavigateTo(destination);
+    }
+
+    private void OnBreakpointChanged(Breakpoint breakpoint)
+    {
+        _drawerVariant = breakpoint < Breakpoint.Md ? DrawerVariant.Temporary : DrawerVariant.Persistent;
+        if (_drawerVariant == DrawerVariant.Temporary)
+        {
+            _isDrawerOpen = false;
+        }
+        StateHasChanged();
+    }
+
+    private void CloseDrawerOnMobile()
+    {
+        if (_drawerVariant == DrawerVariant.Temporary)
+        {
+            _isDrawerOpen = false;
+        }
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeState.OnChange -= OnThemeChanged;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor.css
@@ -1,0 +1,83 @@
+/* MainLayout.razor.css: Styles the adaptive tri-panel layout with smooth transitions and accessibility affordances. */
+:root {
+    color-scheme: light dark;
+}
+
+.crm-layout {
+    min-height: 100vh;
+    background-color: transparent;
+}
+
+.crm-grid {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: 1.25rem;
+    padding: 1.5rem;
+    transition: padding 0.3s ease;
+}
+
+.crm-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 8;
+}
+
+.crm-content {
+    outline: none;
+}
+
+.crm-content-surface {
+    min-height: calc(100vh - 200px);
+    padding: 1.75rem;
+    border-radius: 18px;
+    backdrop-filter: blur(18px);
+    background-color: rgba(255, 255, 255, 0.8);
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.mud-theme-dark .crm-content-surface {
+    background-color: rgba(17, 28, 46, 0.85);
+}
+
+.crm-drawer {
+    border-right: none;
+    background: linear-gradient(180deg, rgba(11, 26, 54, 0.98) 0%, rgba(16, 32, 71, 0.95) 100%);
+    color: rgba(255, 255, 255, 0.87);
+}
+
+.crm-drawer .mud-nav-link {
+    border-radius: 12px;
+    margin: 0.25rem 0;
+    font-weight: 600;
+}
+
+.crm-drawer .mud-nav-link.mud-nav-link-active {
+    background: linear-gradient(90deg, rgba(54, 97, 255, 0.95) 0%, rgba(228, 80, 160, 0.9) 100%);
+    color: #fff;
+    box-shadow: 0 10px 30px rgba(54, 97, 255, 0.35);
+}
+
+.crm-drawer .mud-nav-link:not(.mud-nav-link-active):hover {
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+@media (max-width: 960px) {
+    .crm-grid {
+        padding: 1rem;
+    }
+
+    .crm-content-surface {
+        padding: 1.25rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .crm-grid {
+        padding: 0.75rem;
+    }
+
+    .crm-content-surface {
+        padding: 1rem;
+        border-radius: 14px;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/NavMenu.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/NavMenu.razor
@@ -1,0 +1,65 @@
+@* NavMenu.razor: Delivers role-aware navigation with active state styling and mobile-friendly behavior. *@
+@inject NavigationManager NavigationManager
+@inject NavigationMenuService NavigationMenu
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@implements IDisposable
+
+<MudNavMenu Class="crm-nav-menu" Dense="false" Elevation="0">
+    <MudText Typo="Typo.subtitle2" Class="crm-nav-heading" Role="heading" AriaLevel="2">Workspace Modules</MudText>
+    @foreach (var link in _links)
+    {
+        <MudNavLink Href="@link.Href"
+                    Icon="@link.Icon"
+                    Match="NavLinkMatch.Prefix"
+                    DisableRipple="true"
+                    Class="@GetLinkClass(link)"
+                    OnClick="() => HandleNavigationAsync(link)">
+            <div class="crm-nav-link-content">
+                <span class="crm-nav-link-title">@link.Title</span>
+                <span class="crm-nav-link-description">@link.Description</span>
+            </div>
+        </MudNavLink>
+    }
+</MudNavMenu>
+
+@code {
+    private IReadOnlyList<NavigationLink> _links = Array.Empty<NavigationLink>();
+
+    [Parameter]
+    public EventCallback OnNavigate { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        AuthenticationStateProvider.AuthenticationStateChanged += OnAuthenticationChanged;
+        await LoadLinksAsync();
+    }
+
+    private async Task LoadLinksAsync()
+    {
+        var state = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _links = NavigationMenu.GetLinksForUser(state.User).ToList();
+        StateHasChanged();
+    }
+
+    private string GetLinkClass(NavigationLink link)
+    {
+        return NavigationMenu.IsActive(NavigationManager, link) ? "mud-nav-link-active" : string.Empty;
+    }
+
+    private async Task HandleNavigationAsync(NavigationLink link)
+    {
+        await OnNavigate.InvokeAsync();
+    }
+
+    private async void OnAuthenticationChanged(Task<AuthenticationState> task)
+    {
+        var state = await task;
+        _links = NavigationMenu.GetLinksForUser(state.User).ToList();
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        AuthenticationStateProvider.AuthenticationStateChanged -= OnAuthenticationChanged;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/NavMenu.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Shared/NavMenu.razor.css
@@ -1,0 +1,50 @@
+/* NavMenu.razor.css: Shapes the navigation menu typography and hover interactions. */
+.crm-nav-menu {
+    padding: 1.5rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.crm-nav-heading {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    opacity: 0.75;
+    margin-bottom: 0.75rem;
+}
+
+.crm-nav-link-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+}
+
+.crm-nav-link-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.crm-nav-link-description {
+    font-size: 0.75rem;
+    opacity: 0.75;
+}
+
+.crm-nav-menu .mud-nav-link {
+    padding: 0.85rem 1rem;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.crm-nav-menu .mud-nav-link:hover {
+    transform: translateX(4px);
+}
+
+.crm-nav-menu .mud-nav-link.mud-nav-link-active {
+    color: #ffffff;
+}
+
+@media (max-width: 960px) {
+    .crm-nav-menu {
+        padding: 1.25rem;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/TopBar.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/TopBar.razor
@@ -1,0 +1,178 @@
+@* TopBar.razor: Presents search, session diagnostics, and user profile actions with premium UX. *@
+@inject NavigationManager NavigationManager
+@inject AppThemeState ThemeState
+@inject CorrelationContext CorrelationContext
+@inject AuthStateProvider AppAuthStateProvider
+@inject ISnackbar Snackbar
+@implements IDisposable
+
+<MudPaper Elevation="1" Class="crm-topbar-surface" Square="true">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudIconButton Icon="@Icons.Material.Filled.Menu" Size="Size.Medium" Color="Color.Inherit" aria-label="Toggle navigation" OnClick="ToggleNavigation" />
+            <MudTextField @bind-Value="_searchText"
+                          Placeholder="Search accounts, opportunities, or service cases"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Class="crm-search"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Immediate="false"
+                          OnKeyDown="HandleSearchKey"
+                          aria-label="Global CRM search" />
+        </MudStack>
+
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Justify="Justify.FlexEnd" Class="crm-topbar-actions">
+            <MudTooltip Text="Correlation ID for support handoffs">
+                <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.BubbleChart" Class="crm-correlation-chip">
+                    @CorrelationContext.ShortCorrelationId
+                </MudChip>
+            </MudTooltip>
+            <MudIconButton Icon="@(ThemeState.IsDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.WbSunny)"
+                           Color="Color.Inherit"
+                           aria-label="Toggle theme"
+                           OnClick="ToggleTheme" />
+            <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" OffsetY="true" Class="crm-profile-menu">
+                <ActivatorContent>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="crm-profile-button">
+                        <MudAvatar Size="Size.Medium" Color="Color.Primary" Class="crm-avatar">@_initials</MudAvatar>
+                        <div class="crm-profile-copy">
+                            <span class="crm-profile-name">@_displayName</span>
+                            <span class="crm-profile-role">@_primaryRole</span>
+                        </div>
+                        <MudIcon Icon="@Icons.Material.Filled.KeyboardArrowDown" />
+                    </MudButton>
+                </ActivatorContent>
+                <ChildContent>
+                    <MudMenuItem Icon="@Icons.Material.Filled.AccountBox">View profile</MudMenuItem>
+                    <MudMenuItem Icon="@Icons.Material.Filled.Settings">Preferences</MudMenuItem>
+                    <MudMenuItem Icon="@Icons.Material.Filled.Logout" OnClick="SignOutAsync">Sign out</MudMenuItem>
+                </ChildContent>
+            </MudMenu>
+        </MudStack>
+    </MudStack>
+</MudPaper>
+
+@code {
+    private string? _searchText;
+    private string _displayName = "Guest";
+    private string _primaryRole = "Sign in";
+    private string _initials = "GU";
+
+    [Parameter]
+    public EventCallback OnToggleNavigation { get; set; }
+
+    [Parameter]
+    public EventCallback OnThemeToggle { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnSearch { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        AppAuthStateProvider.AuthenticationStateChanged += OnAuthenticationChanged;
+        await LoadUserProfileAsync(await AppAuthStateProvider.GetAuthenticationStateAsync());
+    }
+
+    private async Task LoadUserProfileAsync(AuthenticationState state)
+    {
+        var user = state.User;
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            _displayName = ResolveDisplayName(user);
+            _primaryRole = ResolvePrimaryRole(user);
+            _initials = DeriveInitials(_displayName);
+        }
+        else
+        {
+            _displayName = "Guest";
+            _primaryRole = "Sign in";
+            _initials = "GU";
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private static string ResolveDisplayName(ClaimsPrincipal user)
+    {
+        return user.Identity?.Name
+               ?? user.FindFirst("name")?.Value
+               ?? user.FindFirst(ClaimTypes.Name)?.Value
+               ?? "Team member";
+    }
+
+    private static string ResolvePrimaryRole(ClaimsPrincipal user)
+    {
+        var roleClaim = user.FindFirst(ClaimTypes.Role)?.Value;
+        if (!string.IsNullOrWhiteSpace(roleClaim))
+        {
+            return roleClaim;
+        }
+
+        var roles = RolePolicies.AllRoles.Where(user.IsInRole).ToArray();
+        return roles.Length > 0 ? string.Join(", ", roles) : "Collaborator";
+    }
+
+    private static string DeriveInitials(string name)
+    {
+        var segments = name.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0)
+        {
+            return "U";
+        }
+
+        return string.Concat(segments.Select(segment => char.ToUpperInvariant(segment[0]))).Substring(0, Math.Min(2, segments.Length));
+    }
+
+    private async Task HandleSearchKey(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+        {
+            await TriggerSearchAsync();
+        }
+    }
+
+    private async Task TriggerSearchAsync()
+    {
+        if (OnSearch.HasDelegate)
+        {
+            await OnSearch.InvokeAsync(_searchText ?? string.Empty);
+        }
+        else
+        {
+            Snackbar.Add("Search is not configured yet. Reach out to your administrator.", Severity.Info);
+        }
+    }
+
+    private async Task ToggleNavigation() => await OnToggleNavigation.InvokeAsync();
+
+    private async Task ToggleTheme()
+    {
+        if (OnThemeToggle.HasDelegate)
+        {
+            await OnThemeToggle.InvokeAsync();
+        }
+        else
+        {
+            ThemeState.ToggleTheme();
+        }
+    }
+
+    private async Task SignOutAsync()
+    {
+        await AppAuthStateProvider.SignOutAsync();
+        Snackbar.Add("You have signed out of CRM Adapter.", Severity.Success);
+        NavigationManager.NavigateTo("/", forceLoad: true);
+    }
+
+    private async void OnAuthenticationChanged(Task<AuthenticationState> authenticationTask)
+    {
+        var state = await authenticationTask;
+        await LoadUserProfileAsync(state);
+    }
+
+    public void Dispose()
+    {
+        AppAuthStateProvider.AuthenticationStateChanged -= OnAuthenticationChanged;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/TopBar.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Shared/TopBar.razor.css
@@ -1,0 +1,72 @@
+/* TopBar.razor.css: Applies premium styling to the top bar controls and profile menu. */
+.crm-topbar-surface {
+    padding: 0.75rem 1.25rem;
+    border-radius: 16px;
+    backdrop-filter: blur(14px);
+}
+
+.crm-search {
+    min-width: 320px;
+    transition: box-shadow 0.2s ease;
+}
+
+.crm-search:focus-within {
+    box-shadow: 0 10px 30px rgba(54, 97, 255, 0.25);
+}
+
+.crm-topbar-actions {
+    flex-wrap: wrap;
+}
+
+.crm-correlation-chip {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+}
+
+.crm-profile-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-transform: none;
+}
+
+.crm-avatar {
+    font-weight: 600;
+}
+
+.crm-profile-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+}
+
+.crm-profile-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.crm-profile-role {
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
+
+@media (max-width: 960px) {
+    .crm-search {
+        min-width: 200px;
+    }
+
+    .crm-profile-copy {
+        display: none;
+    }
+}
+
+@media (max-width: 600px) {
+    .crm-topbar-surface {
+        padding: 0.5rem 0.75rem;
+    }
+
+    .crm-search {
+        min-width: 160px;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Theming/AppThemeState.cs
+++ b/CRMAdapter/CRMAdapter.UI/Theming/AppThemeState.cs
@@ -1,0 +1,116 @@
+// AppThemeState.cs: Manages light/dark MudBlazor themes, typography, and snackbar configuration for the UI.
+using System;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Theming;
+
+public sealed class AppThemeState
+{
+    private readonly MudTheme _lightTheme;
+    private readonly MudTheme _darkTheme;
+    private bool _isDarkMode;
+
+    public AppThemeState()
+    {
+        _lightTheme = BuildLightTheme();
+        _darkTheme = BuildDarkTheme();
+        SnackbarConfiguration = CreateSnackbarConfiguration();
+    }
+
+    public bool IsDarkMode => _isDarkMode;
+
+    public MudTheme ActiveTheme => _isDarkMode ? _darkTheme : _lightTheme;
+
+    public SnackbarConfiguration SnackbarConfiguration { get; }
+
+    public event Action? OnChange;
+
+    public void SetDarkMode(bool isDark)
+    {
+        if (_isDarkMode == isDark)
+        {
+            return;
+        }
+
+        _isDarkMode = isDark;
+        NotifyStateChanged();
+    }
+
+    public void ToggleTheme() => SetDarkMode(!_isDarkMode);
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+
+    private static MudTheme BuildLightTheme()
+    {
+        var paletteLight = new PaletteLight
+        {
+            Primary = "#3661FF",
+            Secondary = "#E450A0",
+            Tertiary = "#0099FF",
+            Info = "#2D9BF0",
+            Success = "#3CC796",
+            Warning = "#FFB74D",
+            Error = "#F87171",
+            Background = "#F5F7FB",
+            Surface = "#FFFFFF",
+            AppbarBackground = "#0B1A36",
+            DrawerBackground = "#102047",
+            DrawerText = "rgba(255,255,255,0.86)",
+            TextPrimary = "rgba(15,23,42,0.92)",
+            TextSecondary = "rgba(51,65,85,0.78)",
+            Divider = "rgba(148,163,184,0.4)"
+        };
+
+        var paletteDark = new PaletteDark
+        {
+            Primary = "#7CA1FF",
+            Secondary = "#F48FB1",
+            Tertiary = "#4FC3F7",
+            Info = "#55C2FF",
+            Success = "#32D296",
+            Warning = "#FFCA7A",
+            Error = "#FF8A80",
+            Background = "#0F172A",
+            Surface = "#111C2E",
+            AppbarBackground = "#111C2E",
+            DrawerBackground = "#0C1424",
+            DrawerText = "rgba(255,255,255,0.85)",
+            TextPrimary = "rgba(255,255,255,0.92)",
+            TextSecondary = "rgba(226,232,240,0.7)",
+            Divider = "rgba(94,106,132,0.5)"
+        };
+
+        return new MudTheme
+        {
+            PaletteLight = paletteLight,
+            PaletteDark = paletteDark,
+            LayoutProperties = new LayoutProperties
+            {
+                DefaultBorderRadius = "12px"
+            }
+        };
+    }
+
+    private static MudTheme BuildDarkTheme()
+    {
+        var lightTheme = BuildLightTheme();
+        return new MudTheme
+        {
+            PaletteDark = lightTheme.PaletteDark,
+            LayoutProperties = lightTheme.LayoutProperties
+        };
+    }
+
+    private static SnackbarConfiguration CreateSnackbarConfiguration()
+    {
+        return new SnackbarConfiguration
+        {
+            PositionClass = Defaults.Classes.Position.TopCenter,
+            PreventDuplicates = true,
+            HideTransitionDuration = 100,
+            ShowTransitionDuration = 150,
+            VisibleStateDuration = 5000,
+            BackgroundBlurred = true
+        };
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/_Imports.razor
+++ b/CRMAdapter/CRMAdapter.UI/_Imports.razor
@@ -1,0 +1,15 @@
+@* _Imports.razor: Centralizes common usings and component namespaces for Razor files. *@
+@using System
+@using System.Linq
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using MudBlazor
+@using CRMAdapter.UI.Shared
+@using CRMAdapter.UI.Navigation
+@using CRMAdapter.UI.Theming
+@using CRMAdapter.UI.Services.Diagnostics
+@using CRMAdapter.UI.Auth

--- a/CRMAdapter/CRMAdapter.UI/appsettings.Development.json
+++ b/CRMAdapter/CRMAdapter.UI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/CRMAdapter/CRMAdapter.UI/appsettings.json
+++ b/CRMAdapter/CRMAdapter.UI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/CRMAdapter/CRMAdapter.UI/wwwroot/app.css
+++ b/CRMAdapter/CRMAdapter.UI/wwwroot/app.css
@@ -1,0 +1,59 @@
+/* app.css: Establishes global typography, smooth transitions, and responsive helpers for CRM Adapter UI. */
+html, body {
+    height: 100%;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", "Segoe UI", sans-serif;
+    background: linear-gradient(160deg, rgba(245, 247, 251, 1) 0%, rgba(236, 239, 249, 1) 100%);
+    color: #0f172a;
+    transition: background 0.4s ease;
+}
+
+body.mud-theme-dark {
+    background: radial-gradient(circle at 10% 20%, rgba(17, 28, 46, 1) 0%, rgba(12, 20, 36, 1) 100%);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+main:focus {
+    outline: 3px solid rgba(54, 97, 255, 0.6);
+    outline-offset: 4px;
+}
+
+.landing-grid {
+    margin-top: 0.5rem;
+}
+
+.landing-hero {
+    padding: 2.5rem;
+    border-radius: 20px;
+    background: linear-gradient(120deg, rgba(54, 97, 255, 0.15) 0%, rgba(228, 80, 160, 0.15) 100%);
+    backdrop-filter: blur(16px);
+}
+
+body.mud-theme-dark .landing-hero {
+    background: linear-gradient(120deg, rgba(124, 161, 255, 0.25) 0%, rgba(244, 143, 177, 0.22) 100%);
+}
+
+.landing-kpi {
+    padding: 1.75rem;
+    border-radius: 18px;
+}
+
+.mud-list-item-text-primary {
+    font-weight: 600;
+}
+
+.mud-chip.crm-correlation-chip {
+    font-size: 0.75rem;
+}

--- a/CRMAdapter/CRMAdapter.UI/wwwroot/favicon.svg
+++ b/CRMAdapter/CRMAdapter.UI/wwwroot/favicon.svg
@@ -1,0 +1,14 @@
+<!-- favicon.svg: Vector favicon for the CRM Adapter UI brand without binary assets. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-labelledby="title desc" role="img">
+  <title>CRM Adapter Icon</title>
+  <desc>Abstract hexagon illustrating secure data connections.</desc>
+  <defs>
+    <linearGradient id="coreGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3651ff" />
+      <stop offset="100%" stop-color="#e450a0" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="#0f172a" />
+  <path d="M32 12l15 9v22l-15 9-15-9V21l15-9z" fill="url(#coreGradient)" stroke="#93c5fd" stroke-width="2" />
+  <circle cx="32" cy="32" r="6" fill="#f8fafc" />
+</svg>

--- a/CRMAdapter/CRMAdapter.sln
+++ b/CRMAdapter/CRMAdapter.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Tests", "Tests\C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Api", "CRMAdapter.Api\CRMAdapter.Api.csproj", "{4DFEF50D-CE19-458A-9D45-73DF04857F02}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.UI", "CRMAdapter.UI\CRMAdapter.UI.csproj", "{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,12 +25,16 @@ Global
 		{677142B4-CBA2-480B-9467-D92D9F241B37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{677142B4-CBA2-480B-9467-D92D9F241B37}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.Build.0 = Release|Any CPU
-                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.Build.0 = Release|Any CPU
-        EndGlobalSection
+		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E2BEA01-6D4F-4A17-955A-1B097AA6581E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- replace the previous PNG favicon with an accessible SVG icon to avoid binary assets in the repository
- update the hosting document to reference the SVG favicon so the UI loads the new vector asset

## Testing
- `dotnet build CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj` *(fails in container: `dotnet` command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d40b86225c832f8f49d56ab99704d3