### PR TITLE
Phase 2: Customers module UI

### DIFF
--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/ActionButtons.razor
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/ActionButtons.razor
@@ -1,0 +1,43 @@
+@* ActionButtons.razor: Normalized action cluster with motion affordances for list rows. *@
+<MudStack Row="true" Spacing="0.5" Class="crm-action-buttons">
+    <MudTooltip Text="View record">
+        <MudIconButton Icon="@Icons.Material.Filled.OpenInNew"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       aria-label="View customer"
+                       OnClick="OnView" />
+    </MudTooltip>
+    <MudTooltip Text="Edit coming soon">
+        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                       Disabled="@(!EditEnabled)"
+                       Color="Color.Default"
+                       Size="Size.Small"
+                       aria-label="Edit customer"
+                       OnClick="OnEdit" />
+    </MudTooltip>
+    <MudTooltip Text="Delete coming soon">
+        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                       Disabled="@(!DeleteEnabled)"
+                       Color="Color.Default"
+                       Size="Size.Small"
+                       aria-label="Delete customer"
+                       OnClick="OnDelete" />
+    </MudTooltip>
+</MudStack>
+
+@code {
+    [Parameter]
+    public EventCallback OnView { get; set; }
+
+    [Parameter]
+    public EventCallback OnEdit { get; set; }
+
+    [Parameter]
+    public EventCallback OnDelete { get; set; }
+
+    [Parameter]
+    public bool EditEnabled { get; set; }
+
+    [Parameter]
+    public bool DeleteEnabled { get; set; }
+}

--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/ActionButtons.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/ActionButtons.razor.css
@@ -1,0 +1,17 @@
+/* ActionButtons.razor.css: Provides hover motion and alignment for action clusters. */
+.crm-action-buttons {
+    justify-content: flex-end;
+}
+
+.crm-action-buttons .mud-icon-button {
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.crm-action-buttons .mud-icon-button:not(.mud-disabled):hover {
+    transform: translateY(-1px) scale(1.05);
+    box-shadow: 0 6px 18px rgba(54, 97, 255, 0.18);
+}
+
+.crm-action-buttons .mud-disabled {
+    opacity: 0.45;
+}

--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerCard.razor
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerCard.razor
@@ -1,0 +1,106 @@
+@* CustomerCard.razor: Premium summary card for quickly scanning customer identity and health signals. *@
+<MudCard Class="crm-customer-card" Elevation="1">
+    <MudCardContent>
+        <MudStack Spacing="2">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1.5">
+                <MudAvatar Size="Size.Large"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           Class="crm-customer-card-avatar">
+                    @Initials
+                </MudAvatar>
+                <MudStack Spacing="0.5">
+                    <MudText Typo="Typo.h6" Class="crm-customer-card-name">@Name</MudText>
+                    @if (!string.IsNullOrWhiteSpace(Email))
+                    {
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0.5" Class="crm-customer-card-meta">
+                            <MudIcon Icon="@Icons.Material.Filled.Email" Size="Size.Small" />
+                            <MudText Typo="Typo.caption">@Email</MudText>
+                        </MudStack>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(Phone))
+                    {
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0.5" Class="crm-customer-card-meta">
+                            <MudIcon Icon="@Icons.Material.Filled.Call" Size="Size.Small" />
+                            <MudText Typo="Typo.caption">@Phone</MudText>
+                        </MudStack>
+                    }
+                </MudStack>
+            </MudStack>
+
+            <MudStack Row="true" Spacing="1" Wrap="true">
+                <MudChip Color="Color.Info" Variant="Variant.Outlined" Size="Size.Small" Class="crm-customer-card-chip">
+                    <MudIcon Icon="@Icons.Material.Filled.DirectionsCar" Size="Size.Small" Class="me-1" />
+                    @VehicleCount vehicles
+                </MudChip>
+                <MudChip Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small" Class="crm-customer-card-chip">
+                    <MudIcon Icon="@Icons.Material.Filled.ReceiptLong" Size="Size.Small" Class="me-1" />
+                    Last invoice @FormatLastInvoiceDate(LastInvoiceDate)
+                </MudChip>
+            </MudStack>
+
+            @if (!string.IsNullOrWhiteSpace(Notes))
+            {
+                <MudPaper Elevation="0" Class="crm-customer-card-notes">
+                    <MudText Typo="Typo.overline" Class="mb-1">Account narrative</MudText>
+                    <MudText Typo="Typo.body2">@Notes</MudText>
+                </MudPaper>
+            }
+
+            @if (ChildContent is not null)
+            {
+                <MudDivider />
+                <MudStack Spacing="1">
+                    @ChildContent
+                </MudStack>
+            }
+        </MudStack>
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter]
+    public string Name { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? Email { get; set; }
+
+    [Parameter]
+    public string? Phone { get; set; }
+
+    [Parameter]
+    public int VehicleCount { get; set; }
+
+    [Parameter]
+    public DateTime? LastInvoiceDate { get; set; }
+
+    [Parameter]
+    public string? Notes { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private string Initials => DeriveInitials(Name);
+
+    private static string DeriveInitials(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "C";
+        }
+
+        var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+        {
+            return "C";
+        }
+
+        var initials = string.Concat(parts.Take(2).Select(p => char.ToUpperInvariant(p[0])));
+        return initials;
+    }
+
+    private static string FormatLastInvoiceDate(DateTime? date)
+    {
+        return date.HasValue ? date.Value.ToString("MMM dd, yyyy") : "not yet";
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerCard.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerCard.razor.css
@@ -1,0 +1,39 @@
+/* CustomerCard.razor.css: Applies luxurious styling to the reusable customer summary card. */
+.crm-customer-card {
+    border-radius: 18px;
+    transition: transform 160ms ease, box-shadow 200ms ease;
+}
+
+.crm-customer-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+}
+
+.crm-customer-card-avatar {
+    font-weight: 600;
+}
+
+.crm-customer-card-name {
+    letter-spacing: -0.01em;
+}
+
+.crm-customer-card-meta .mud-icon {
+    color: rgba(100, 116, 139, 0.85);
+}
+
+.crm-customer-card-chip {
+    border-radius: 999px;
+    font-weight: 500;
+}
+
+.crm-customer-card-notes {
+    background: linear-gradient(135deg, rgba(54, 97, 255, 0.08), rgba(228, 80, 160, 0.08));
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+}
+
+@media (max-width: 599.95px) {
+    .crm-customer-card {
+        border-radius: 16px;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerSearchBar.razor
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerSearchBar.razor
@@ -1,0 +1,77 @@
+@* CustomerSearchBar.razor: Debounced search field that emits customer directory queries for instant filtering. *@
+<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="crm-customer-search">
+    <MudTextField @bind-Value="_query"
+                  Variant="Variant.Outlined"
+                  Placeholder="@Placeholder"
+                  Adornment="Adornment.Start"
+                  AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true"
+                  DebounceInterval="@DebounceInterval"
+                  OnDebouncedValueChanged="HandleDebouncedValueChanged"
+                  OnKeyDown="HandleKeyDown"
+                  Class="crm-customer-search-input"
+                  aria-label="Search customers" />
+    @if (!string.IsNullOrWhiteSpace(_query))
+    {
+        <MudTooltip Text="Clear search">
+            <MudIconButton Icon="@Icons.Material.Filled.Close"
+                           Color="Color.Default"
+                           Class="crm-customer-search-clear"
+                           aria-label="Clear search"
+                           OnClick="ClearAsync" />
+        </MudTooltip>
+    }
+</MudStack>
+
+@code {
+    private string _query = string.Empty;
+
+    [Parameter]
+    public string Placeholder { get; set; } = "Search customers";
+
+    [Parameter]
+    public int DebounceInterval { get; set; } = 250;
+
+    [Parameter]
+    public EventCallback<string> OnSearch { get; set; }
+
+    [Parameter]
+    public EventCallback OnCleared { get; set; }
+
+    private async Task HandleDebouncedValueChanged(string value)
+    {
+        _query = value;
+        if (OnSearch.HasDelegate)
+        {
+            await OnSearch.InvokeAsync(value);
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+        {
+            if (OnSearch.HasDelegate)
+            {
+                await OnSearch.InvokeAsync(_query);
+            }
+        }
+        else if (args.Key == "Escape")
+        {
+            await ClearAsync();
+        }
+    }
+
+    private async Task ClearAsync()
+    {
+        _query = string.Empty;
+        if (OnCleared.HasDelegate)
+        {
+            await OnCleared.InvokeAsync();
+        }
+        else if (OnSearch.HasDelegate)
+        {
+            await OnSearch.InvokeAsync(string.Empty);
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerSearchBar.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Components/Customers/CustomerSearchBar.razor.css
@@ -1,0 +1,39 @@
+/* CustomerSearchBar.razor.css: Styles the debounced search field with responsive affordances. */
+.crm-customer-search {
+    width: 100%;
+}
+
+.crm-customer-search-input {
+    flex: 1;
+    min-width: 0;
+    transition: box-shadow 150ms ease, transform 150ms ease;
+}
+
+.crm-customer-search-input .mud-input-input {
+    font-size: 0.95rem;
+}
+
+.crm-customer-search-input:hover,
+.crm-customer-search-input:focus-within {
+    box-shadow: 0 8px 24px rgba(54, 97, 255, 0.12);
+    transform: translateY(-1px);
+}
+
+.crm-customer-search-clear {
+    transition: transform 150ms ease;
+}
+
+.crm-customer-search-clear:hover {
+    transform: scale(1.05);
+}
+
+@media (max-width: 599.95px) {
+    .crm-customer-search {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .crm-customer-search-clear {
+        margin-left: auto;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Navigation/NavigationMenuService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Navigation/NavigationMenuService.cs
@@ -14,6 +14,7 @@ public sealed class NavigationMenuService
     private static readonly IReadOnlyList<NavigationLink> Links = new List<NavigationLink>
     {
         new("Command Center", Icons.Material.Filled.DashboardCustomize, "/", "Executive overview with actionable KPIs.", RolePolicies.AllRoles),
+        new("Customers", Icons.Material.Filled.PeopleAlt, "/customers", "360° customer directory and relationship insights.", RolePolicies.AllRoles),
         new("Operations", Icons.Material.Filled.PrecisionManufacturing, "/operations", "Order orchestration and fulfillment visibility.", new[] { RolePolicies.Admin, RolePolicies.Manager, RolePolicies.Clerk }),
         new("Field Service", Icons.Material.Filled.HomeRepairService, "/field-service", "Technician dispatching and status intelligence.", new[] { RolePolicies.Tech, RolePolicies.Manager }),
         new("Data Stewardship", Icons.Material.Filled.Storage, "/data-quality", "Data quality dashboards and stewardship workflows.", new[] { RolePolicies.Admin, RolePolicies.Manager }),

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/Detail.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/Detail.razor
@@ -1,0 +1,154 @@
+@* Detail.razor: Immersive customer 360 with contextual insights and related data workspaces. *@
+@page "/customers/{CustomerId:guid}"
+@attribute [Authorize(Roles=$"{RolePolicies.Admin},{RolePolicies.Manager},{RolePolicies.Clerk},{RolePolicies.Tech}")]
+@inject ICustomerDirectory CustomerDirectory
+@inject NavigationManager NavigationManager
+
+<MudStack Spacing="3" Class="crm-customer-detail">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Justify="Justify.SpaceBetween">
+        <MudButton Variant="Variant.Text"
+                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                   OnClick="NavigateBack"
+                   Color="Color.Default">
+            Back to customers
+        </MudButton>
+        <MudChip Color="Color.Success" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.VerifiedUser" Class="crm-health-chip">
+            Relationship healthy
+        </MudChip>
+    </MudStack>
+
+    @if (_isLoading)
+    {
+        <MudPaper Elevation="0" Class="pa-6">
+            <MudProgressCircular Indeterminate="true" Size="Size.Large" />
+        </MudPaper>
+    }
+    else if (_customer is null)
+    {
+        <MudPaper Elevation="1" Class="pa-6 text-center">
+            <MudIcon Icon="@Icons.Material.Filled.PersonSearch" Size="Size.Large" Color="Color.Secondary" Class="mb-2" />
+            <MudText Typo="Typo.h6">We could not locate that customer</MudText>
+            <MudText Typo="Typo.body2" Class="mud-secondary-text">Select a customer from the directory to continue.</MudText>
+            <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-4" OnClick="NavigateBack">Return to directory</MudButton>
+        </MudPaper>
+    }
+    else
+    {
+        <MudGrid Spacing="3">
+            <MudItem Xs="12" Lg="5">
+                <CustomerCard Name="@_customer.Name"
+                              Email="@_customer.Email"
+                              Phone="@_customer.Phone"
+                              VehicleCount="@_customer.Vehicles.Count"
+                              LastInvoiceDate="@_customer.Invoices.OrderByDescending(i => i.IssuedOn).FirstOrDefault()?.IssuedOn"
+                              Notes="@_customer.Notes">
+                    <MudStack Row="true" Spacing="1" Wrap="true">
+                        <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.NoteAdd" Color="Color.Primary">
+                            Log touchpoint
+                        </MudButton>
+                        <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.BuildCircle" Color="Color.Secondary">
+                            Create service case
+                        </MudButton>
+                    </MudStack>
+                </CustomerCard>
+            </MudItem>
+            <MudItem Xs="12" Lg="7">
+                <MudPaper Elevation="1" Class="crm-detail-tabs">
+                    <MudTabs Rounded="true" ApplyEffects="true" KeepPanelsAlive="true">
+                        <MudTabPanel Text="Vehicles" Icon="@Icons.Material.Filled.DirectionsCar">
+                            <MudTable Items="@_customer.Vehicles" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm">
+                                <HeaderContent>
+                                    <MudTh>VIN</MudTh>
+                                    <MudTh>Year</MudTh>
+                                    <MudTh>Model</MudTh>
+                                    <MudTh>Status</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="VIN">@context.Vin</MudTd>
+                                    <MudTd DataLabel="Year">@context.Year</MudTd>
+                                    <MudTd DataLabel="Model">@context.MakeModel</MudTd>
+                                    <MudTd DataLabel="Status">
+                                        <MudChip Color="@ResolveStatusColor(context.Status)" Variant="Variant.Filled" Size="Size.Small">@context.Status</MudChip>
+                                    </MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudTabPanel>
+                        <MudTabPanel Text="Invoices" Icon="@Icons.Material.Filled.ReceiptLong">
+                            <MudTable Items="@_customer.Invoices" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm">
+                                <HeaderContent>
+                                    <MudTh>Invoice</MudTh>
+                                    <MudTh>Date</MudTh>
+                                    <MudTh>Amount</MudTh>
+                                    <MudTh>Status</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Invoice">@context.InvoiceNumber</MudTd>
+                                    <MudTd DataLabel="Date">@context.IssuedOn.ToString("MMM dd, yyyy")</MudTd>
+                                    <MudTd DataLabel="Amount">@FormatCurrency(context.Amount)</MudTd>
+                                    <MudTd DataLabel="Status">
+                                        <MudChip Color="@ResolveStatusColor(context.Status)" Variant="Variant.Outlined" Size="Size.Small">@context.Status</MudChip>
+                                    </MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudTabPanel>
+                        <MudTabPanel Text="Appointments" Icon="@Icons.Material.Filled.EventAvailable">
+                            <MudTable Items="@_customer.Appointments" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm">
+                                <HeaderContent>
+                                    <MudTh>When</MudTh>
+                                    <MudTh>Subject</MudTh>
+                                    <MudTh>Owner</MudTh>
+                                    <MudTh>Status</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="When">@context.ScheduledFor.ToLocalTime().ToString("MMM dd, yyyy h:mm tt")</MudTd>
+                                    <MudTd DataLabel="Subject">@context.Subject</MudTd>
+                                    <MudTd DataLabel="Owner">@context.Owner</MudTd>
+                                    <MudTd DataLabel="Status">
+                                        <MudChip Color="@ResolveStatusColor(context.Status)" Variant="Variant.Outlined" Size="Size.Small">@context.Status</MudChip>
+                                    </MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        </MudTabPanel>
+                    </MudTabs>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    }
+</MudStack>
+
+@code {
+    [Parameter]
+    public Guid CustomerId { get; set; }
+
+    private CustomerDetail? _customer;
+    private bool _isLoading;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _isLoading = true;
+        _customer = await CustomerDirectory.GetCustomerAsync(CustomerId);
+        _isLoading = false;
+    }
+
+    private void NavigateBack()
+    {
+        NavigationManager.NavigateTo("/customers");
+    }
+
+    private static string FormatCurrency(decimal amount)
+    {
+        return string.Format(System.Globalization.CultureInfo.CurrentCulture, "{0:C}", amount);
+    }
+
+    private static Color ResolveStatusColor(string status)
+    {
+        return status switch
+        {
+            "Paid" or "Active" or "Completed" => Color.Success,
+            "Processing" or "Scheduled" or "In service" => Color.Info,
+            "Draft" or "Awaiting parts" or "In diagnostics" => Color.Warning,
+            "Past due" or "Retired" => Color.Error,
+            _ => Color.Default
+        };
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/Detail.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/Detail.razor.css
@@ -1,0 +1,41 @@
+/* Detail.razor.css: Styles the responsive customer detail 360 workspace. */
+.crm-customer-detail {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+}
+
+.crm-health-chip {
+    font-weight: 600;
+}
+
+.crm-detail-tabs {
+    border-radius: 20px;
+    padding: 1.5rem;
+}
+
+.crm-detail-tabs .mud-tabs-toolbar {
+    margin-bottom: 1rem;
+}
+
+.crm-detail-tabs .mud-tab-panel {
+    padding: 0;
+}
+
+.crm-detail-tabs .mud-table {
+    border-radius: 12px;
+}
+
+.crm-detail-tabs .mud-table tr:hover {
+    background-color: rgba(54, 97, 255, 0.06);
+}
+
+@media (max-width: 959.95px) {
+    .crm-customer-detail {
+        padding-inline: 1rem;
+    }
+
+    .crm-detail-tabs {
+        padding: 1rem;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor
@@ -1,0 +1,147 @@
+@* List.razor: Customers workspace landing page with responsive table, instant filtering, and action affordances. *@
+@page "/customers"
+@attribute [Authorize(Roles=$"{RolePolicies.Admin},{RolePolicies.Manager},{RolePolicies.Clerk},{RolePolicies.Tech}")]
+@inject ICustomerDirectory CustomerDirectory
+@inject NavigationManager NavigationManager
+
+<MudStack Spacing="3" Class="crm-customers-container">
+    <MudStack Spacing="0.5">
+        <MudText Typo="Typo.h4" Class="crm-page-title">Customer success hub</MudText>
+        <MudText Typo="Typo.body1" Class="crm-page-subtitle">Review active relationships, unlock insights, and accelerate follow-ups.</MudText>
+    </MudStack>
+
+    <MudPaper Elevation="1" Class="crm-search-shell" Square="false">
+        <CustomerSearchBar OnSearch="HandleSearchAsync"
+                           OnCleared="ResetFilter"
+                           Placeholder="Search by name, email, or phone"
+                           DebounceInterval="220" />
+        <MudChip Variant="Variant.Outlined" Color="Color.Primary" Class="crm-result-count" Icon="@Icons.Material.Filled.Group">
+            @_filteredCustomers.Count customers
+        </MudChip>
+    </MudPaper>
+
+    <MudPaper Elevation="1" Class="crm-table-shell">
+        <MudTable Items="@_filteredCustomers"
+                  Loading="@_isLoading"
+                  Hover="true"
+                  Bordered="false"
+                  Dense="false"
+                  Breakpoint="Breakpoint.Sm"
+                  RowsPerPage="@_rowsPerPage"
+                  RowsPerPageOptions="@_rowsPerPageOptions"
+                  @ref="_table"
+                  OnRowClick="HandleRowClick"
+                  RowClassFunc="@(_ => \"crm-customer-row\")">
+            <ToolBarContent>
+                <MudText Typo="Typo.subtitle1">Directory</MudText>
+            </ToolBarContent>
+            <HeaderContent>
+                <MudTh>Name</MudTh>
+                <MudTh>Phone</MudTh>
+                <MudTh>Email</MudTh>
+                <MudTh class="text-center">Vehicles</MudTh>
+                <MudTh>Last invoice</MudTh>
+                <MudTh Class="text-right">Actions</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Name">
+                    <MudStack Spacing="0.5">
+                        <MudText Typo="Typo.subtitle2">@context.Name</MudText>
+                        <MudHidden Breakpoint="Breakpoint.MdAndUp">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Email</MudText>
+                        </MudHidden>
+                    </MudStack>
+                </MudTd>
+                <MudTd DataLabel="Phone">@context.Phone</MudTd>
+                <MudTd DataLabel="Email" Class="crm-email-cell">@context.Email</MudTd>
+                <MudTd DataLabel="Vehicles" Align="DataGridCellAlign.Center">@context.VehicleCount</MudTd>
+                <MudTd DataLabel="Last invoice">@FormatLastInvoiceDate(context.LastInvoiceDate)</MudTd>
+                <MudTd DataLabel="Actions" Class="text-right">
+                    <ActionButtons OnView="@(() => NavigateToDetail(context.Id))" />
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center" Class="pa-6">
+                    <MudIcon Icon="@Icons.Material.Filled.SearchOff" Color="Color.Secondary" Size="Size.Large" />
+                    <MudText Typo="Typo.subtitle1">No customers match that search</MudText>
+                    <MudText Typo="Typo.body2" Class="mud-secondary-text">Try a different phrase or clear the filter.</MudText>
+                </MudStack>
+            </NoRecordsContent>
+        </MudTable>
+    </MudPaper>
+
+    <MudHidden Breakpoint="Breakpoint.MdAndUp">
+        <MudStack Spacing="2">
+            @foreach (var customer in _filteredCustomers)
+            {
+                <CustomerCard Name="@customer.Name"
+                              Email="@customer.Email"
+                              Phone="@customer.Phone"
+                              VehicleCount="@customer.VehicleCount"
+                              LastInvoiceDate="@customer.LastInvoiceDate">
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               EndIcon="@Icons.Material.Filled.ArrowForward"
+                               OnClick="@(() => NavigateToDetail(customer.Id))">
+                        View profile
+                    </MudButton>
+                </CustomerCard>
+            }
+        </MudStack>
+    </MudHidden>
+</MudStack>
+
+@code {
+    private readonly int[] _rowsPerPageOptions = { 10, 25, 50 };
+    private IReadOnlyList<CustomerSummary> _allCustomers = Array.Empty<CustomerSummary>();
+    private List<CustomerSummary> _filteredCustomers = new();
+    private MudTable<CustomerSummary>? _table;
+    private int _rowsPerPage = 10;
+    private bool _isLoading;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isLoading = true;
+        _allCustomers = await CustomerDirectory.GetCustomersAsync();
+        _filteredCustomers = _allCustomers.ToList();
+        _isLoading = false;
+    }
+
+    private async Task HandleSearchAsync(string query)
+    {
+        var sanitized = query?.Trim() ?? string.Empty;
+        _filteredCustomers = string.IsNullOrWhiteSpace(sanitized)
+            ? _allCustomers.ToList()
+            : _allCustomers.Where(customer => Matches(customer, sanitized)).ToList();
+
+        _table?.SetPage(0);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task ResetFilter()
+    {
+        return HandleSearchAsync(string.Empty);
+    }
+
+    private static bool Matches(CustomerSummary customer, string query)
+    {
+        return customer.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+               || customer.Email.Contains(query, StringComparison.OrdinalIgnoreCase)
+               || customer.Phone.Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void HandleRowClick(TableRowClickEventArgs<CustomerSummary> args)
+    {
+        NavigateToDetail(args.Item.Id);
+    }
+
+    private void NavigateToDetail(Guid id)
+    {
+        NavigationManager.NavigateTo($"/customers/{id}");
+    }
+
+    private static string FormatLastInvoiceDate(DateTime? date)
+    {
+        return date.HasValue ? date.Value.ToString("MMM dd, yyyy") : "—";
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor.css
@@ -1,0 +1,64 @@
+/* List.razor.css: Elevates the customers table with responsive padding and hover effects. */
+.crm-customers-container {
+    max-width: 1160px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+}
+
+.crm-page-title {
+    letter-spacing: -0.01em;
+}
+
+.crm-page-subtitle {
+    color: rgba(71, 85, 105, 0.85);
+}
+
+.crm-search-shell {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    border-radius: 16px;
+}
+
+.crm-result-count {
+    font-weight: 500;
+}
+
+.crm-table-shell {
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.crm-customer-row {
+    cursor: pointer;
+    transition: transform 140ms ease, background-color 140ms ease;
+}
+
+.crm-customer-row:hover {
+    transform: translateX(4px);
+    background-color: rgba(54, 97, 255, 0.08);
+}
+
+.crm-email-cell {
+    max-width: 260px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+@media (max-width: 959.95px) {
+    .crm-customers-container {
+        padding-inline: 1rem;
+    }
+
+    .crm-search-shell {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .crm-result-count {
+        align-self: flex-start;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Program.cs
+++ b/CRMAdapter/CRMAdapter.UI/Program.cs
@@ -4,6 +4,7 @@ using CRMAdapter.UI.Auth;
 using CRMAdapter.UI.Hosting;
 using CRMAdapter.UI.Infrastructure.Security;
 using CRMAdapter.UI.Navigation;
+using CRMAdapter.UI.Services.Customers;
 using CRMAdapter.UI.Services.Diagnostics;
 using CRMAdapter.UI.Theming;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -70,6 +71,7 @@ builder.Services.AddScoped<JwtAuthProvider>();
 builder.Services.AddSingleton<NavigationMenuService>();
 builder.Services.AddScoped<AppThemeState>();
 builder.Services.AddScoped<CorrelationContext>();
+builder.Services.AddSingleton<ICustomerDirectory, InMemoryCustomerDirectory>();
 
 builder.Services.AddHttpClient(HttpClientNames.CrmApi, client =>
     {

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/ICustomerDirectory.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/ICustomerDirectory.cs
@@ -1,0 +1,15 @@
+// ICustomerDirectory.cs: Abstraction for retrieving customer summaries and detail projections.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Services.Customers.Models;
+
+namespace CRMAdapter.UI.Services.Customers;
+
+public interface ICustomerDirectory
+{
+    Task<IReadOnlyList<CustomerSummary>> GetCustomersAsync(CancellationToken cancellationToken = default);
+
+    Task<CustomerDetail?> GetCustomerAsync(Guid customerId, CancellationToken cancellationToken = default);
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/InMemoryCustomerDirectory.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/InMemoryCustomerDirectory.cs
@@ -1,0 +1,128 @@
+// InMemoryCustomerDirectory.cs: Provides curated sample customers until real CRM endpoints are wired up.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Services.Customers.Models;
+
+namespace CRMAdapter.UI.Services.Customers;
+
+public sealed class InMemoryCustomerDirectory : ICustomerDirectory
+{
+    private readonly IReadOnlyList<CustomerDetail> _customers;
+
+    public InMemoryCustomerDirectory()
+    {
+        _customers = SeedCustomers();
+    }
+
+    public Task<IReadOnlyList<CustomerSummary>> GetCustomersAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var summaries = _customers
+            .Select(customer => new CustomerSummary(
+                customer.Id,
+                customer.Name,
+                customer.Phone,
+                customer.Email,
+                customer.Vehicles.Count,
+                customer.Invoices.OrderByDescending(i => i.IssuedOn).FirstOrDefault()?.IssuedOn))
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<CustomerSummary>>(summaries);
+    }
+
+    public Task<CustomerDetail?> GetCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var customer = _customers.FirstOrDefault(c => c.Id == customerId);
+        return Task.FromResult(customer);
+    }
+
+    private static IReadOnlyList<CustomerDetail> SeedCustomers()
+    {
+        return new List<CustomerDetail>
+        {
+            new(
+                Guid.Parse("d2b3f3f5-9fb5-4bcb-bf70-5c8f7a7d1a10"),
+                "Apex Logistics",
+                "opsdesk@apexlogistics.co",
+                "+1 (312) 555-0188",
+                "National 3PL partner prioritizing electrified fleets and predictive maintenance programs.",
+                new List<VehicleRecord>
+                {
+                    new("1FTEW1EP3PKA12345", "2023", "Ford F-150 Lightning", "Active"),
+                    new("1GC4YVEY2NF152233", "2022", "Chevrolet Silverado HD", "In service"),
+                    new("3N1AB8CV3MY225601", "2021", "Nissan Leaf Fleet", "Active")
+                },
+                new List<InvoiceRecord>
+                {
+                    new("INV-1045", CreateDate(2024, 11, 18), 24800.00m, "Paid"),
+                    new("INV-1021", CreateDate(2024, 9, 2), 18740.50m, "Paid"),
+                    new("INV-0998", CreateDate(2024, 6, 27), 22110.75m, "Past due")
+                },
+                new List<AppointmentRecord>
+                {
+                    new(CreateDate(2024, 12, 2, 14, 0), "Q1 capacity planning", "Mia Chen", "Scheduled"),
+                    new(CreateDate(2024, 11, 8, 10, 30), "Fleet telemetry rollout", "Derrick James", "Completed")
+                }
+            ),
+            new(
+                Guid.Parse("8b1a3dd2-f54b-4e38-bd5e-68d3e16f0ad9"),
+                "Northwind Fleet Services",
+                "hello@northwindfleet.com",
+                "+1 (206) 555-0148",
+                "Regional service network delivering rapid-response maintenance for commercial EVs.",
+                new List<VehicleRecord>
+                {
+                    new("5YJSA1E26JF275911", "2020", "Tesla Model S Performance", "Active"),
+                    new("1C6SRFMT1LN245877", "2021", "RAM 1500 Tradesman", "Awaiting parts")
+                },
+                new List<InvoiceRecord>
+                {
+                    new("INV-2087", CreateDate(2024, 10, 29), 9450.00m, "Processing"),
+                    new("INV-2043", CreateDate(2024, 8, 15), 11220.00m, "Paid"),
+                    new("INV-2001", CreateDate(2024, 5, 3), 6580.00m, "Paid")
+                },
+                new List<AppointmentRecord>
+                {
+                    new(CreateDate(2024, 11, 21, 9, 0), "Battery wellness audit", "Priya Patel", "Scheduled"),
+                    new(CreateDate(2024, 10, 5, 16, 0), "Emergency roadside review", "Leo Zhang", "Completed"),
+                    new(CreateDate(2024, 9, 12, 11, 30), "Executive business review", "Avery Ross", "Completed")
+                }
+            ),
+            new(
+                Guid.Parse("34d7fe27-6d2d-4d4e-98d4-92f0039bbacd"),
+                "Starlight Mobility",
+                "support@starlightmobility.ai",
+                "+1 (415) 555-0190",
+                "Autonomous shuttle innovator leveraging CRM Adapter to orchestrate deployments.",
+                new List<VehicleRecord>
+                {
+                    new("WBY1Z4C58EV547221", "2024", "BMW iX Shuttle", "Active"),
+                    new("JHMZE2H75AS015462", "2022", "Honda Insight Fleet", "In diagnostics"),
+                    new("2C4RC1BG5HR677451", "2021", "Chrysler Pacifica Hybrid", "Active"),
+                    new("1HGCV1F39LA067811", "2020", "Honda Accord Hybrid", "Retired")
+                },
+                new List<InvoiceRecord>
+                {
+                    new("INV-3104", CreateDate(2024, 12, 1), 40250.00m, "Draft"),
+                    new("INV-3059", CreateDate(2024, 9, 19), 38990.00m, "Paid"),
+                    new("INV-2995", CreateDate(2024, 7, 23), 41575.00m, "Paid")
+                },
+                new List<AppointmentRecord>
+                {
+                    new(CreateDate(2024, 12, 15, 13, 0), "Pilot launch readiness", "Jordan Blake", "Scheduled"),
+                    new(CreateDate(2024, 11, 2, 15, 30), "ADAS analytics review", "Nora Alvarez", "Scheduled"),
+                    new(CreateDate(2024, 8, 28, 10, 0), "Safety certification retro", "Isabella Moore", "Completed")
+                }
+            )
+        };
+    }
+
+    private static DateTime CreateDate(int year, int month, int day, int hour = 0, int minute = 0)
+    {
+        return DateTime.SpecifyKind(new DateTime(year, month, day, hour, minute, 0), DateTimeKind.Utc);
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/AppointmentRecord.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/AppointmentRecord.cs
@@ -1,0 +1,10 @@
+// AppointmentRecord.cs: Tracks scheduled engagements associated with a customer.
+using System;
+
+namespace CRMAdapter.UI.Services.Customers.Models;
+
+public sealed record AppointmentRecord(
+    DateTime ScheduledFor,
+    string Subject,
+    string Owner,
+    string Status);

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/CustomerDetail.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/CustomerDetail.cs
@@ -1,0 +1,15 @@
+// CustomerDetail.cs: Rich customer projection aggregating contact metadata and related collections.
+using System;
+using System.Collections.Generic;
+
+namespace CRMAdapter.UI.Services.Customers.Models;
+
+public sealed record CustomerDetail(
+    Guid Id,
+    string Name,
+    string Email,
+    string Phone,
+    string? Notes,
+    IReadOnlyList<VehicleRecord> Vehicles,
+    IReadOnlyList<InvoiceRecord> Invoices,
+    IReadOnlyList<AppointmentRecord> Appointments);

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/CustomerSummary.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/CustomerSummary.cs
@@ -1,0 +1,12 @@
+// CustomerSummary.cs: Lightweight projection for customer table and card representations.
+using System;
+
+namespace CRMAdapter.UI.Services.Customers.Models;
+
+public sealed record CustomerSummary(
+    Guid Id,
+    string Name,
+    string Phone,
+    string Email,
+    int VehicleCount,
+    DateTime? LastInvoiceDate);

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/InvoiceRecord.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/InvoiceRecord.cs
@@ -1,0 +1,10 @@
+// InvoiceRecord.cs: Captures financial metadata for customer invoice listings.
+using System;
+
+namespace CRMAdapter.UI.Services.Customers.Models;
+
+public sealed record InvoiceRecord(
+    string InvoiceNumber,
+    DateTime IssuedOn,
+    decimal Amount,
+    string Status);

--- a/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/VehicleRecord.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Customers/Models/VehicleRecord.cs
@@ -1,0 +1,9 @@
+// VehicleRecord.cs: Represents a customer's vehicle asset for tabular display in the detail view.
+
+namespace CRMAdapter.UI.Services.Customers.Models;
+
+public sealed record VehicleRecord(
+    string Vin,
+    string Year,
+    string MakeModel,
+    string Status);

--- a/CRMAdapter/CRMAdapter.UI/_Imports.razor
+++ b/CRMAdapter/CRMAdapter.UI/_Imports.razor
@@ -13,3 +13,6 @@
 @using CRMAdapter.UI.Theming
 @using CRMAdapter.UI.Services.Diagnostics
 @using CRMAdapter.UI.Auth
+@using CRMAdapter.UI.Services.Customers
+@using CRMAdapter.UI.Services.Customers.Models
+@using CRMAdapter.UI.Components.Customers

--- a/CRMAdapter/CRMAdapter.sln
+++ b/CRMAdapter/CRMAdapter.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.Api", "CRMAdapte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.UI", "CRMAdapter.UI\CRMAdapter.UI.csproj", "{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRMAdapter.UI.Tests", "Tests\CRMAdapter.UI.Tests\CRMAdapter.UI.Tests.csproj", "{FB5A5B66-FFA7-448A-B667-0F8654E5D326}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,9 +34,13 @@ Global
 		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4DFEF50D-CE19-458A-9D45-73DF04857F02}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3535CDF8-1CC1-48F1-8EAE-F3A748E33571}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FB5A5B66-FFA7-448A-B667-0F8654E5D326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FB5A5B66-FFA7-448A-B667-0F8654E5D326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FB5A5B66-FFA7-448A-B667-0F8654E5D326}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FB5A5B66-FFA7-448A-B667-0F8654E5D326}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/CRMAdapter/Tests/CRMAdapter.UI.Tests/CRMAdapter.UI.Tests.csproj
+++ b/CRMAdapter/Tests/CRMAdapter.UI.Tests/CRMAdapter.UI.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>CRMAdapter.UI.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CRMAdapter.UI/CRMAdapter.UI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.30.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/CRMAdapter/Tests/CRMAdapter.UI.Tests/Customers/CustomersPageTests.cs
+++ b/CRMAdapter/Tests/CRMAdapter.UI.Tests/Customers/CustomersPageTests.cs
@@ -1,0 +1,65 @@
+// CustomersPageTests.cs: Integration coverage for the customer listing and detail experiences.
+using System.Linq;
+using Bunit;
+using CRMAdapter.UI.Pages.Customers;
+using CRMAdapter.UI.Services.Customers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace CRMAdapter.UI.Tests.Customers;
+
+public sealed class CustomersPageTests : TestContext
+{
+    public CustomersPageTests()
+    {
+        Services.AddMudServices();
+        Services.AddSingleton<ICustomerDirectory, InMemoryCustomerDirectory>();
+    }
+
+    [Fact]
+    public void CustomersList_ShouldRenderMockCustomers()
+    {
+        var component = RenderComponent<List>();
+
+        component.WaitForAssertion(() =>
+        {
+            var rows = component.FindAll("table tbody tr");
+            rows.Should().NotBeEmpty();
+        });
+    }
+
+    [Fact]
+    public void CustomersList_SearchFiltersRows()
+    {
+        var component = RenderComponent<List>();
+
+        component.WaitForAssertion(() => component.FindAll("table tbody tr").Count.Should().BeGreaterThan(0));
+
+        var input = component.Find("input");
+        input.Change("Starlight");
+
+        component.WaitForAssertion(() =>
+        {
+            var rows = component.FindAll("table tbody tr");
+            rows.Should().HaveCount(1);
+            rows[0].TextContent.Should().Contain("Starlight Mobility");
+        });
+    }
+
+    [Fact]
+    public void CustomerDetail_ShouldRenderAllTabs()
+    {
+        var directory = Services.GetRequiredService<ICustomerDirectory>();
+        var firstCustomer = directory.GetCustomersAsync().GetAwaiter().GetResult().First();
+
+        var detail = RenderComponent<Detail>(parameters => parameters.Add(p => p.CustomerId, firstCustomer.Id));
+
+        detail.WaitForAssertion(() =>
+        {
+            var tabs = detail.FindAll("button[role='tab']");
+            tabs.Select(t => t.TextContent.Trim()).Should().Contain(new[] { "Vehicles", "Invoices", "Appointments" });
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a customers workspace with a responsive MudTable, debounced search, and mobile-friendly cards
- implement a customer 360 detail page backed by an in-memory directory and reusable action components
- introduce a Blazor UI test project with bUnit integration coverage for the list and detail routes

## Testing
- dotnet test CRMAdapter/CRMAdapter.sln *(fails: dotnet CLI is unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d41c7557ec832f88f0b4b7cdbfe4b3