### PR TITLE
Add SignalR realtime hub and UI subscriptions

### DIFF
--- a/CRMAdapter/CRMAdapter.Api/Events/EventDispatcher.cs
+++ b/CRMAdapter/CRMAdapter.Api/Events/EventDispatcher.cs
@@ -1,0 +1,95 @@
+// File: EventDispatcher.cs
+// Summary: Static helper used by adapters to broadcast SignalR events to connected clients.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Hubs;
+using CRMAdapter.Api.Middleware;
+using CRMAdapter.CommonContracts.Realtime;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Events;
+
+/// <summary>
+/// Provides a central location for adapters to publish real-time CRM events.
+/// </summary>
+public static class EventDispatcher
+{
+    private static IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Configures the dispatcher with the root application service provider.
+    /// </summary>
+    /// <param name="serviceProvider">Service provider used to resolve hub dependencies.</param>
+    public static void Configure(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    /// <summary>Broadcasts a customer created event.</summary>
+    public static Task BroadcastCustomerCreatedAsync(CustomerCreatedEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.CustomerCreated(payload), nameof(ICrmEventsClient.CustomerCreated), cancellationToken);
+
+    /// <summary>Broadcasts a customer updated event.</summary>
+    public static Task BroadcastCustomerUpdatedAsync(CustomerUpdatedEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.CustomerUpdated(payload), nameof(ICrmEventsClient.CustomerUpdated), cancellationToken);
+
+    /// <summary>Broadcasts an invoice created event.</summary>
+    public static Task BroadcastInvoiceCreatedAsync(InvoiceCreatedEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.InvoiceCreated(payload), nameof(ICrmEventsClient.InvoiceCreated), cancellationToken);
+
+    /// <summary>Broadcasts an invoice paid event.</summary>
+    public static Task BroadcastInvoicePaidAsync(InvoicePaidEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.InvoicePaid(payload), nameof(ICrmEventsClient.InvoicePaid), cancellationToken);
+
+    /// <summary>Broadcasts a vehicle added event.</summary>
+    public static Task BroadcastVehicleAddedAsync(VehicleAddedEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.VehicleAdded(payload), nameof(ICrmEventsClient.VehicleAdded), cancellationToken);
+
+    /// <summary>Broadcasts an appointment scheduled event.</summary>
+    public static Task BroadcastAppointmentScheduledAsync(AppointmentScheduledEvent payload, CancellationToken cancellationToken = default)
+        => BroadcastAsync(client => client.AppointmentScheduled(payload), nameof(ICrmEventsClient.AppointmentScheduled), cancellationToken);
+
+    private static async Task BroadcastAsync(
+        Func<ICrmEventsClient, Task> broadcast,
+        string eventName,
+        CancellationToken cancellationToken)
+    {
+        if (broadcast is null)
+        {
+            throw new ArgumentNullException(nameof(broadcast));
+        }
+
+        if (_serviceProvider is null)
+        {
+            return;
+        }
+
+        await using var scope = _serviceProvider.CreateAsyncScope();
+        var hubContext = scope.ServiceProvider.GetRequiredService<IHubContext<CrmEventsHub, ICrmEventsClient>>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(EventDispatcher));
+        var httpContextAccessor = scope.ServiceProvider.GetService<IHttpContextAccessor>();
+
+        var correlationId = httpContextAccessor?.HttpContext?.Items?[CorrelationIdMiddleware.CorrelationHeaderName]?.ToString();
+        using (logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["EventName"] = eventName,
+            ["CorrelationId"] = correlationId,
+        }))
+        {
+            try
+            {
+                await broadcast(hubContext.Clients.All).ConfigureAwait(false);
+                logger.LogInformation("Broadcasted CRM event {EventName} to connected clients.", eventName);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                logger.LogError(ex, "Failed to broadcast CRM event {EventName}.", eventName);
+            }
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Hubs/CrmEventsHub.cs
+++ b/CRMAdapter/CRMAdapter.Api/Hubs/CrmEventsHub.cs
@@ -1,0 +1,103 @@
+// File: CrmEventsHub.cs
+// Summary: SignalR hub that broadcasts CRM domain events to authenticated clients.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Middleware;
+using CRMAdapter.CommonContracts.Realtime;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Hubs;
+
+/// <summary>
+/// Defines strongly typed client methods that the hub can invoke.
+/// </summary>
+public interface ICrmEventsClient
+{
+    /// <summary>Broadcasts that a customer was created.</summary>
+    /// <param name="payload">Customer payload pushed to clients.</param>
+    Task CustomerCreated(CustomerCreatedEvent payload);
+
+    /// <summary>Broadcasts that a customer was updated.</summary>
+    /// <param name="payload">Customer payload pushed to clients.</param>
+    Task CustomerUpdated(CustomerUpdatedEvent payload);
+
+    /// <summary>Broadcasts that an invoice was created.</summary>
+    /// <param name="payload">Invoice payload pushed to clients.</param>
+    Task InvoiceCreated(InvoiceCreatedEvent payload);
+
+    /// <summary>Broadcasts that an invoice was paid.</summary>
+    /// <param name="payload">Invoice payment payload.</param>
+    Task InvoicePaid(InvoicePaidEvent payload);
+
+    /// <summary>Broadcasts that a vehicle was added.</summary>
+    /// <param name="payload">Vehicle payload pushed to clients.</param>
+    Task VehicleAdded(VehicleAddedEvent payload);
+
+    /// <summary>Broadcasts that an appointment was scheduled.</summary>
+    /// <param name="payload">Appointment payload pushed to clients.</param>
+    Task AppointmentScheduled(AppointmentScheduledEvent payload);
+}
+
+/// <summary>
+/// Hub used to publish CRM domain events to connected Blazor clients in real time.
+/// </summary>
+[Authorize(Roles = "Admin,Manager,Clerk,Tech")]
+public sealed class CrmEventsHub : Hub<ICrmEventsClient>
+{
+    private readonly ILogger<CrmEventsHub> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CrmEventsHub"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used to capture connection lifecycle telemetry.</param>
+    public CrmEventsHub(ILogger<CrmEventsHub> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override Task OnConnectedAsync()
+    {
+        var httpContext = Context.GetHttpContext();
+        var correlationId = httpContext?.Request.Headers[CorrelationIdMiddleware.CorrelationHeaderName].ToString();
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            correlationId = Guid.NewGuid().ToString("N");
+        }
+
+        using (_logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["CorrelationId"] = correlationId,
+            ["ConnectionId"] = Context.ConnectionId,
+        }))
+        {
+            _logger.LogInformation("Client {ConnectionId} connected to CRM events hub.", Context.ConnectionId);
+        }
+
+        return base.OnConnectedAsync();
+    }
+
+    /// <inheritdoc />
+    public override Task OnDisconnectedAsync(Exception? exception)
+    {
+        using (_logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["ConnectionId"] = Context.ConnectionId,
+        }))
+        {
+            if (exception is null)
+            {
+                _logger.LogInformation("Client {ConnectionId} disconnected from CRM events hub.", Context.ConnectionId);
+            }
+            else
+            {
+                _logger.LogWarning(exception, "Client {ConnectionId} disconnected from CRM events hub due to an error.", Context.ConnectionId);
+            }
+        }
+
+        return base.OnDisconnectedAsync(exception);
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Startup.cs
+++ b/CRMAdapter/CRMAdapter.Api/Startup.cs
@@ -5,6 +5,8 @@ using System.Data.Common;
 using System.IO;
 using System.IdentityModel.Tokens.Jwt;
 using CRMAdapter.Api.Endpoints;
+using CRMAdapter.Api.Events;
+using CRMAdapter.Api.Hubs;
 using CRMAdapter.Api.Middleware;
 using CRMAdapter.Api.Security;
 using CRMAdapter.CommonContracts;
@@ -99,6 +101,11 @@ public sealed class Startup
         services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().VehicleAdapter);
         services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().InvoiceAdapter);
         services.AddScoped(provider => provider.GetRequiredService<AdapterBundle>().AppointmentAdapter);
+
+        services.AddSignalR(options =>
+        {
+            options.EnableDetailedErrors = _environment.IsDevelopment();
+        });
     }
 
     /// <summary>
@@ -135,6 +142,9 @@ public sealed class Startup
         app.MapVehiclesEndpoints();
         app.MapInvoicesEndpoints();
         app.MapAppointmentsEndpoints();
+        app.MapHub<CrmEventsHub>("/crmhub");
+
+        EventDispatcher.Configure(app.Services);
     }
 
     private void ConfigureSwagger(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions options)

--- a/CRMAdapter/CRMAdapter.UI/Auth/AuthStateProvider.cs
+++ b/CRMAdapter/CRMAdapter.UI/Auth/AuthStateProvider.cs
@@ -88,6 +88,14 @@ public sealed class AuthStateProvider : AuthenticationStateProvider
         NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(_currentUser)));
     }
 
+    /// <summary>
+    /// Retrieves the currently stored access token without mutating state.
+    /// </summary>
+    public Task<string?> GetAccessTokenAsync()
+    {
+        return ReadTokenAsync();
+    }
+
     private ClaimsPrincipal BuildPrincipal(string accessToken)
     {
         var token = _tokenHandler.ReadJwtToken(accessToken);

--- a/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
+++ b/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
@@ -10,8 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
     <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CRMAdapter.Core\CRMAdapter.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor
@@ -2,6 +2,7 @@
 @page "/customers"
 @attribute [Authorize(Roles=$"{RolePolicies.Admin},{RolePolicies.Manager},{RolePolicies.Clerk},{RolePolicies.Tech}")]
 @inject ICustomerService CustomerDirectory
+@inject CustomerRealtimeService CustomerRealtime
 @inject NavigationManager NavigationManager
 
 <MudStack Spacing="3" Class="crm-customers-container">
@@ -31,7 +32,7 @@
                   RowsPerPageOptions="@_rowsPerPageOptions"
                   @ref="_table"
                   OnRowClick="HandleRowClick"
-                  RowClassFunc="@(_ => \"crm-customer-row\")">
+                  RowClassFunc="ResolveRowClass">
             <ToolBarContent>
                 <MudText Typo="Typo.subtitle1">Directory</MudText>
             </ToolBarContent>
@@ -93,23 +94,33 @@
 
 @code {
     private readonly int[] _rowsPerPageOptions = { 10, 25, 50 };
-    private IReadOnlyList<CustomerSummary> _allCustomers = Array.Empty<CustomerSummary>();
+    private List<CustomerSummary> _allCustomers = new();
     private List<CustomerSummary> _filteredCustomers = new();
     private MudTable<CustomerSummary>? _table;
     private int _rowsPerPage = 10;
     private bool _isLoading;
+    private string _currentFilter = string.Empty;
+    private readonly Dictionary<Guid, string> _rowStates = new();
+    private IDisposable? _customerCreatedSubscription;
+    private IDisposable? _customerUpdatedSubscription;
+    private IDisposable? _reconnectedSubscription;
 
     protected override async Task OnInitializedAsync()
     {
         _isLoading = true;
-        _allCustomers = await CustomerDirectory.GetCustomersAsync();
-        _filteredCustomers = _allCustomers.ToList();
+        await ReloadCustomersAsync();
         _isLoading = false;
+
+        await CustomerRealtime.EnsureConnectedAsync();
+        _customerCreatedSubscription = CustomerRealtime.OnCustomerCreated(payload => _ = OnCustomerCreatedAsync(payload));
+        _customerUpdatedSubscription = CustomerRealtime.OnCustomerUpdated(payload => _ = OnCustomerUpdatedAsync(payload));
+        _reconnectedSubscription = CustomerRealtime.RegisterReconnected(() => _ = OnHubReconnectedAsync());
     }
 
     private async Task HandleSearchAsync(string query)
     {
         var sanitized = query?.Trim() ?? string.Empty;
+        _currentFilter = sanitized;
         _filteredCustomers = string.IsNullOrWhiteSpace(sanitized)
             ? _allCustomers.ToList()
             : _allCustomers.Where(customer => Matches(customer, sanitized)).ToList();
@@ -123,11 +134,15 @@
         return HandleSearchAsync(string.Empty);
     }
 
-    private static bool Matches(CustomerSummary customer, string query)
+    private string ResolveRowClass(CustomerSummary summary)
     {
-        return customer.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
-               || customer.Email.Contains(query, StringComparison.OrdinalIgnoreCase)
-               || customer.Phone.Contains(query, StringComparison.OrdinalIgnoreCase);
+        var classes = new List<string> { "crm-customer-row" };
+        if (_rowStates.TryGetValue(summary.Id, out var stateClass))
+        {
+            classes.Add(stateClass);
+        }
+
+        return string.Join(' ', classes);
     }
 
     private void HandleRowClick(TableRowClickEventArgs<CustomerSummary> args)
@@ -143,5 +158,104 @@
     private static string FormatLastInvoiceDate(DateTime? date)
     {
         return date.HasValue ? date.Value.ToString("MMM dd, yyyy") : "—";
+    }
+
+    private static bool Matches(CustomerSummary customer, string query)
+    {
+        return customer.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+               || customer.Email.Contains(query, StringComparison.OrdinalIgnoreCase)
+               || customer.Phone.Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task OnCustomerCreatedAsync(CustomerCreatedEvent payload)
+    {
+        await InvokeAsync(async () =>
+        {
+            var summary = new CustomerSummary(payload.Id, payload.Name, payload.Phone, payload.Email, payload.VehicleCount, payload.LastInvoiceDate);
+            UpsertCustomer(summary);
+            await TriggerRowStateAsync(summary.Id, "crm-customer-row--new").ConfigureAwait(false);
+            StateHasChanged();
+        });
+    }
+
+    private async Task OnCustomerUpdatedAsync(CustomerUpdatedEvent payload)
+    {
+        await InvokeAsync(async () =>
+        {
+            var summary = new CustomerSummary(payload.Id, payload.Name, payload.Phone, payload.Email, payload.VehicleCount, payload.LastInvoiceDate);
+            UpsertCustomer(summary);
+            await TriggerRowStateAsync(summary.Id, "crm-customer-row--updated").ConfigureAwait(false);
+            StateHasChanged();
+        });
+    }
+
+    private Task OnHubReconnectedAsync()
+    {
+        return InvokeAsync(async () =>
+        {
+            await ReloadCustomersAsync().ConfigureAwait(false);
+            StateHasChanged();
+        });
+    }
+
+    private void UpsertCustomer(CustomerSummary summary)
+    {
+        var allIndex = _allCustomers.FindIndex(customer => customer.Id == summary.Id);
+        if (allIndex >= 0)
+        {
+            _allCustomers[allIndex] = summary;
+        }
+        else
+        {
+            _allCustomers.Insert(0, summary);
+        }
+
+        if (string.IsNullOrWhiteSpace(_currentFilter) || Matches(summary, _currentFilter))
+        {
+            var filteredIndex = _filteredCustomers.FindIndex(customer => customer.Id == summary.Id);
+            if (filteredIndex >= 0)
+            {
+                _filteredCustomers[filteredIndex] = summary;
+            }
+            else
+            {
+                _filteredCustomers.Insert(0, summary);
+            }
+        }
+        else
+        {
+            _filteredCustomers.RemoveAll(customer => customer.Id == summary.Id);
+        }
+    }
+
+    private async Task TriggerRowStateAsync(Guid id, string cssClass)
+    {
+        _rowStates[id] = cssClass;
+        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        await InvokeAsync(() =>
+        {
+            if (_rowStates.TryGetValue(id, out var existing) && existing == cssClass)
+            {
+                _rowStates.Remove(id);
+                StateHasChanged();
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private async Task ReloadCustomersAsync()
+    {
+        var customers = await CustomerDirectory.GetCustomersAsync();
+        _allCustomers = customers.ToList();
+        _filteredCustomers = string.IsNullOrWhiteSpace(_currentFilter)
+            ? _allCustomers.ToList()
+            : _allCustomers.Where(customer => Matches(customer, _currentFilter)).ToList();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _customerCreatedSubscription?.Dispose();
+        _customerUpdatedSubscription?.Dispose();
+        _reconnectedSubscription?.Dispose();
+        await Task.CompletedTask;
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Customers/List.razor.css
@@ -41,6 +41,36 @@
     background-color: rgba(54, 97, 255, 0.08);
 }
 
+.crm-customer-row--new {
+    animation: crm-customer-slide-in 0.35s ease-out, crm-customer-highlight 3s ease-out;
+}
+
+.crm-customer-row--updated {
+    animation: crm-customer-highlight 2.5s ease-out;
+}
+
+@keyframes crm-customer-slide-in {
+    from {
+        transform: translateX(-12px);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes crm-customer-highlight {
+    from {
+        background-color: rgba(54, 97, 255, 0.18);
+    }
+
+    to {
+        background-color: transparent;
+    }
+}
+
 .crm-email-cell {
     max-width: 260px;
     white-space: nowrap;

--- a/CRMAdapter/CRMAdapter.UI/Pages/Dashboard/Overview.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Dashboard/Overview.razor
@@ -2,6 +2,11 @@
 @page "/dashboard"
 @attribute [Authorize(Roles=$"{RolePolicies.Admin},{RolePolicies.Manager},{RolePolicies.Clerk}")]
 @inject IDashboardService Analytics
+@inject CustomerRealtimeService CustomerRealtime
+@inject InvoiceRealtimeService InvoiceRealtime
+@inject VehicleRealtimeService VehicleRealtime
+@inject AppointmentRealtimeService AppointmentRealtime
+@implements IAsyncDisposable
 
 <MudStack Spacing="3" Class="crm-dashboard-overview">
     <MudStack Spacing="0.5">
@@ -89,11 +94,24 @@
     private IReadOnlyList<ChartSeries> _statusSeries = Array.Empty<ChartSeries>();
     private IReadOnlyList<string> _vehiclesServicedLabels = Array.Empty<string>();
     private IReadOnlyList<ChartSeries> _vehiclesServicedSeries = Array.Empty<ChartSeries>();
+    private readonly List<IDisposable> _subscriptions = new();
 
     protected override async Task OnInitializedAsync()
     {
         _snapshot = await Analytics.GetSnapshotAsync();
         BuildCharts();
+
+        await CustomerRealtime.EnsureConnectedAsync();
+        await InvoiceRealtime.EnsureConnectedAsync();
+        await VehicleRealtime.EnsureConnectedAsync();
+        await AppointmentRealtime.EnsureConnectedAsync();
+
+        _subscriptions.Add(CustomerRealtime.OnCustomerCreated(_ => _ = RefreshSnapshotAsync()));
+        _subscriptions.Add(CustomerRealtime.OnCustomerUpdated(_ => _ = RefreshSnapshotAsync()));
+        _subscriptions.Add(InvoiceRealtime.OnInvoiceCreated(_ => _ = RefreshSnapshotAsync()));
+        _subscriptions.Add(InvoiceRealtime.OnInvoicePaid(_ => _ = RefreshSnapshotAsync()));
+        _subscriptions.Add(VehicleRealtime.OnVehicleAdded(_ => _ = RefreshSnapshotAsync()));
+        _subscriptions.Add(AppointmentRealtime.OnAppointmentScheduled(_ => _ = RefreshSnapshotAsync()));
     }
 
     private void BuildCharts()
@@ -132,5 +150,26 @@
                 Data = _snapshot.VehiclesServiced.Select(point => (double)point.CompletedCount).ToArray()
             }
         };
+    }
+
+    private Task RefreshSnapshotAsync()
+    {
+        return InvokeAsync(async () =>
+        {
+            _snapshot = await Analytics.GetSnapshotAsync().ConfigureAwait(false);
+            BuildCharts();
+            StateHasChanged();
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var subscription in _subscriptions)
+        {
+            subscription.Dispose();
+        }
+
+        _subscriptions.Clear();
+        await Task.CompletedTask;
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Pages/Invoices/List.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Invoices/List.razor
@@ -2,6 +2,7 @@
 @page "/invoices"
 @attribute [Authorize(Roles=$"{RolePolicies.Admin},{RolePolicies.Manager},{RolePolicies.Clerk}")]
 @inject IInvoiceService InvoiceWorkspace
+@inject InvoiceRealtimeService InvoiceRealtime
 @inject NavigationManager NavigationManager
 
 <MudStack Spacing="3" Class="crm-invoices-container">
@@ -181,19 +182,27 @@
 
 @code {
     private readonly int[] _rowsPerPageOptions = { 10, 25, 50 };
-    private IReadOnlyList<InvoiceSummary> _allInvoices = Array.Empty<InvoiceSummary>();
+    private List<InvoiceSummary> _allInvoices = new();
     private List<InvoiceSummary> _filteredInvoices = new();
     private MudTable<InvoiceSummary>? _table;
     private int _rowsPerPage = 10;
     private bool _isLoading;
     private string _search = string.Empty;
+    private readonly Dictionary<Guid, string> _rowStates = new();
+    private IDisposable? _invoiceCreatedSubscription;
+    private IDisposable? _invoicePaidSubscription;
+    private IDisposable? _reconnectedSubscription;
 
     protected override async Task OnInitializedAsync()
     {
         _isLoading = true;
-        _allInvoices = await InvoiceWorkspace.GetInvoicesAsync();
-        _filteredInvoices = _allInvoices.ToList();
+        await ReloadInvoicesAsync();
         _isLoading = false;
+
+        await InvoiceRealtime.EnsureConnectedAsync();
+        _invoiceCreatedSubscription = InvoiceRealtime.OnInvoiceCreated(payload => _ = OnInvoiceCreatedAsync(payload));
+        _invoicePaidSubscription = InvoiceRealtime.OnInvoicePaid(payload => _ = OnInvoicePaidAsync(payload));
+        _reconnectedSubscription = InvoiceRealtime.RegisterReconnected(() => _ = OnHubReconnectedAsync());
     }
 
     private async Task HandleSearch(string value)
@@ -223,6 +232,11 @@
             classes.Add("crm-invoice-row--overdue");
         }
 
+        if (_rowStates.TryGetValue(invoice.Id, out var stateClass))
+        {
+            classes.Add(stateClass);
+        }
+
         return string.Join(' ', classes);
     }
 
@@ -243,5 +257,124 @@
     private static string FormatCurrency(decimal amount)
     {
         return string.Format(System.Globalization.CultureInfo.CurrentCulture, "{0:C}", amount);
+    }
+
+    private async Task OnInvoiceCreatedAsync(InvoiceCreatedEvent payload)
+    {
+        await InvokeAsync(() =>
+        {
+            var summary = new InvoiceSummary(
+                payload.Id,
+                payload.InvoiceNumber,
+                payload.CustomerId,
+                payload.CustomerName,
+                payload.VehicleId,
+                payload.VehicleVin,
+                payload.IssuedOn,
+                payload.Status,
+                payload.Total,
+                payload.BalanceDue);
+            UpsertInvoice(summary);
+            _ = TriggerRowStateAsync(summary.Id, "crm-invoice-row--new");
+            StateHasChanged();
+            return Task.CompletedTask;
+        });
+    }
+
+    private async Task OnInvoicePaidAsync(InvoicePaidEvent payload)
+    {
+        await InvokeAsync(() =>
+        {
+            var index = _allInvoices.FindIndex(invoice => invoice.Id == payload.Id);
+            if (index < 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            var updated = _allInvoices[index] with { Status = "Paid", BalanceDue = 0m };
+            _allInvoices[index] = updated;
+
+            var filteredIndex = _filteredInvoices.FindIndex(invoice => invoice.Id == payload.Id);
+            if (filteredIndex >= 0)
+            {
+                _filteredInvoices[filteredIndex] = updated;
+            }
+
+            _ = TriggerRowStateAsync(updated.Id, "crm-invoice-row--paid");
+            StateHasChanged();
+            return Task.CompletedTask;
+        });
+    }
+
+    private Task OnHubReconnectedAsync()
+    {
+        return InvokeAsync(async () =>
+        {
+            await ReloadInvoicesAsync().ConfigureAwait(false);
+            StateHasChanged();
+        });
+    }
+
+    private void UpsertInvoice(InvoiceSummary summary)
+    {
+        var existingIndex = _allInvoices.FindIndex(invoice => invoice.Id == summary.Id);
+        if (existingIndex >= 0)
+        {
+            _allInvoices[existingIndex] = summary;
+        }
+        else
+        {
+            _allInvoices.Insert(0, summary);
+        }
+
+        var sanitized = _search.Trim();
+        if (string.IsNullOrWhiteSpace(sanitized) || Matches(summary, sanitized))
+        {
+            var filteredIndex = _filteredInvoices.FindIndex(invoice => invoice.Id == summary.Id);
+            if (filteredIndex >= 0)
+            {
+                _filteredInvoices[filteredIndex] = summary;
+            }
+            else
+            {
+                _filteredInvoices.Insert(0, summary);
+            }
+        }
+        else
+        {
+            _filteredInvoices.RemoveAll(invoice => invoice.Id == summary.Id);
+        }
+    }
+
+    private async Task TriggerRowStateAsync(Guid id, string cssClass)
+    {
+        _rowStates[id] = cssClass;
+        await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        await InvokeAsync(() =>
+        {
+            if (_rowStates.TryGetValue(id, out var existing) && existing == cssClass)
+            {
+                _rowStates.Remove(id);
+                StateHasChanged();
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private async Task ReloadInvoicesAsync()
+    {
+        var invoices = await InvoiceWorkspace.GetInvoicesAsync();
+        _allInvoices = invoices.ToList();
+        var sanitized = _search.Trim();
+        _filteredInvoices = string.IsNullOrWhiteSpace(sanitized)
+            ? _allInvoices.ToList()
+            : _allInvoices.Where(invoice => Matches(invoice, sanitized)).ToList();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _invoiceCreatedSubscription?.Dispose();
+        _invoicePaidSubscription?.Dispose();
+        _reconnectedSubscription?.Dispose();
+        await Task.CompletedTask;
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Pages/Invoices/List.razor.css
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Invoices/List.razor.css
@@ -16,8 +16,38 @@
     background-color: rgba(211, 47, 47, 0.08);
 }
 
+.crm-invoice-row--new {
+    animation: crm-invoice-slide-in 0.35s ease-out, crm-invoice-flash 2.5s ease-out;
+}
+
+.crm-invoice-row--paid {
+    animation: crm-invoice-flash 2.5s ease-out;
+}
+
 .crm-balance-danger {
     color: var(--mud-palette-error);
     font-weight: 600;
+}
+
+@keyframes crm-invoice-slide-in {
+    from {
+        transform: translateY(-8px);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@keyframes crm-invoice-flash {
+    from {
+        background-color: rgba(46, 125, 50, 0.16);
+    }
+
+    to {
+        background-color: transparent;
+    }
 }
 

--- a/CRMAdapter/CRMAdapter.UI/Program.cs
+++ b/CRMAdapter/CRMAdapter.UI/Program.cs
@@ -17,6 +17,7 @@ using CRMAdapter.UI.Services.Mock.Customers;
 using CRMAdapter.UI.Services.Mock.Dashboard;
 using CRMAdapter.UI.Services.Mock.Invoices;
 using CRMAdapter.UI.Services.Mock.Vehicles;
+using CRMAdapter.UI.Services.Realtime;
 using CRMAdapter.UI.Theming;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -112,6 +113,13 @@ builder.Services.AddScoped<IVehicleService>(sp => sp.GetRequiredService<IDataSou
 builder.Services.AddScoped<IInvoiceService>(sp => sp.GetRequiredService<IDataSourceStrategy>().GetService<IInvoiceService>());
 builder.Services.AddScoped<IAppointmentService>(sp => sp.GetRequiredService<IDataSourceStrategy>().GetService<IAppointmentService>());
 builder.Services.AddScoped<IDashboardService>(sp => sp.GetRequiredService<IDataSourceStrategy>().GetService<IDashboardService>());
+
+builder.Services.AddSingleton<IHubConnectionProxyFactory, SignalRHubConnectionProxyFactory>();
+builder.Services.AddScoped<RealtimeHubConnection>();
+builder.Services.AddScoped<CustomerRealtimeService>();
+builder.Services.AddScoped<InvoiceRealtimeService>();
+builder.Services.AddScoped<VehicleRealtimeService>();
+builder.Services.AddScoped<AppointmentRealtimeService>();
 
 builder.Services.AddMudServices(config =>
 {

--- a/CRMAdapter/CRMAdapter.UI/Services/Realtime/AppointmentRealtimeService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Realtime/AppointmentRealtimeService.cs
@@ -1,0 +1,128 @@
+// AppointmentRealtimeService.cs: Bridges appointment realtime notifications into UI callbacks.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using CRMAdapter.UI.Auth;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Services.Realtime;
+
+/// <summary>
+/// Dispatches appointment scheduling events to interested components with role-aware notifications.
+/// </summary>
+public sealed class AppointmentRealtimeService : IAsyncDisposable
+{
+    private readonly RealtimeHubConnection _hubConnection;
+    private readonly AuthStateProvider _authStateProvider;
+    private readonly ILogger<AppointmentRealtimeService> _logger;
+    private readonly ISnackbar _snackbar;
+    private readonly List<Action<AppointmentScheduledEvent>> _appointmentHandlers = new();
+    private readonly IDisposable _appointmentSubscription;
+
+    public AppointmentRealtimeService(
+        RealtimeHubConnection hubConnection,
+        AuthStateProvider authStateProvider,
+        ILogger<AppointmentRealtimeService> logger,
+        ISnackbar snackbar)
+    {
+        _hubConnection = hubConnection ?? throw new ArgumentNullException(nameof(hubConnection));
+        _authStateProvider = authStateProvider ?? throw new ArgumentNullException(nameof(authStateProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snackbar = snackbar ?? throw new ArgumentNullException(nameof(snackbar));
+
+        _appointmentSubscription = _hubConnection.RegisterAppointmentScheduled(HandleAppointmentScheduled);
+    }
+
+    public Task EnsureConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        return _hubConnection.EnsureConnectedAsync(cancellationToken);
+    }
+
+    public IDisposable OnAppointmentScheduled(Action<AppointmentScheduledEvent> callback) => Register(_appointmentHandlers, callback);
+
+    private void HandleAppointmentScheduled(AppointmentScheduledEvent payload)
+    {
+        _logger.LogInformation("Appointment scheduled for {CustomerName} on {Scheduled}.", payload.CustomerName, payload.ScheduledFor);
+        var localTime = payload.ScheduledFor.ToLocalTime().ToString("h:mm tt", CultureInfo.CurrentCulture);
+        var isClerk = _authStateProvider.CurrentUser.IsInRole(RolePolicies.Clerk);
+        var message = isClerk
+            ? $"New appointment scheduled at {localTime}"
+            : $"Appointment booked for {payload.CustomerName} · {localTime}";
+        _snackbar.Add(message, Severity.Info);
+        Notify(_appointmentHandlers, payload);
+    }
+
+    private static IDisposable Register<T>(ICollection<Action<T>> handlers, Action<T> callback)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static void Notify<T>(ICollection<Action<T>> handlers, T payload)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        Action<T>[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch
+            {
+                // Ignore downstream errors to keep other subscribers alive.
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _appointmentSubscription.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _isDisposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _onDispose();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Realtime/CustomerRealtimeService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Realtime/CustomerRealtimeService.cs
@@ -1,0 +1,132 @@
+// CustomerRealtimeService.cs: Provides strongly typed callbacks for customer-specific realtime events.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Services.Realtime;
+
+/// <summary>
+/// Coordinates customer realtime events and surfaces them to Blazor components.
+/// </summary>
+public sealed class CustomerRealtimeService : IAsyncDisposable
+{
+    private readonly RealtimeHubConnection _hubConnection;
+    private readonly ILogger<CustomerRealtimeService> _logger;
+    private readonly ISnackbar _snackbar;
+    private readonly List<Action<CustomerCreatedEvent>> _createdHandlers = new();
+    private readonly List<Action<CustomerUpdatedEvent>> _updatedHandlers = new();
+    private readonly IDisposable _createdSubscription;
+    private readonly IDisposable _updatedSubscription;
+
+    public CustomerRealtimeService(
+        RealtimeHubConnection hubConnection,
+        ILogger<CustomerRealtimeService> logger,
+        ISnackbar snackbar)
+    {
+        _hubConnection = hubConnection ?? throw new ArgumentNullException(nameof(hubConnection));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snackbar = snackbar ?? throw new ArgumentNullException(nameof(snackbar));
+
+        _createdSubscription = _hubConnection.RegisterCustomerCreated(HandleCustomerCreated);
+        _updatedSubscription = _hubConnection.RegisterCustomerUpdated(HandleCustomerUpdated);
+    }
+
+    public Task EnsureConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        return _hubConnection.EnsureConnectedAsync(cancellationToken);
+    }
+
+    public IDisposable OnCustomerCreated(Action<CustomerCreatedEvent> callback) => Register(_createdHandlers, callback);
+
+    public IDisposable OnCustomerUpdated(Action<CustomerUpdatedEvent> callback) => Register(_updatedHandlers, callback);
+
+    private void HandleCustomerCreated(CustomerCreatedEvent payload)
+    {
+        _logger.LogInformation("Received CustomerCreated event for {CustomerName}.", payload.Name);
+        _snackbar.Add($"New customer added: {payload.Name}", Severity.Success);
+        Notify(_createdHandlers, payload);
+    }
+
+    private void HandleCustomerUpdated(CustomerUpdatedEvent payload)
+    {
+        _logger.LogInformation("Received CustomerUpdated event for {CustomerName}.", payload.Name);
+        var vehicleMessage = payload.VehicleCount == 1 ? "vehicle" : "vehicles";
+        _snackbar.Add($"Updated {payload.Name} · {payload.VehicleCount} {vehicleMessage}", Severity.Info);
+        Notify(_updatedHandlers, payload);
+    }
+
+    private static IDisposable Register<T>(ICollection<Action<T>> handlers, Action<T> callback)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static void Notify<T>(ICollection<Action<T>> handlers, T payload)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        Action<T>[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch
+            {
+                // Ignore downstream errors to keep other subscribers alive.
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _createdSubscription.Dispose();
+        _updatedSubscription.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _isDisposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _onDispose();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Realtime/InvoiceRealtimeService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Realtime/InvoiceRealtimeService.cs
@@ -1,0 +1,141 @@
+// InvoiceRealtimeService.cs: Surfaces invoice realtime events with role-aware notifications.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using CRMAdapter.UI.Auth;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Services.Realtime;
+
+/// <summary>
+/// Provides typed callbacks for invoice-related realtime events.
+/// </summary>
+public sealed class InvoiceRealtimeService : IAsyncDisposable
+{
+    private readonly RealtimeHubConnection _hubConnection;
+    private readonly AuthStateProvider _authStateProvider;
+    private readonly ILogger<InvoiceRealtimeService> _logger;
+    private readonly ISnackbar _snackbar;
+    private readonly List<Action<InvoiceCreatedEvent>> _createdHandlers = new();
+    private readonly List<Action<InvoicePaidEvent>> _paidHandlers = new();
+    private readonly IDisposable _createdSubscription;
+    private readonly IDisposable _paidSubscription;
+
+    public InvoiceRealtimeService(
+        RealtimeHubConnection hubConnection,
+        AuthStateProvider authStateProvider,
+        ILogger<InvoiceRealtimeService> logger,
+        ISnackbar snackbar)
+    {
+        _hubConnection = hubConnection ?? throw new ArgumentNullException(nameof(hubConnection));
+        _authStateProvider = authStateProvider ?? throw new ArgumentNullException(nameof(authStateProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snackbar = snackbar ?? throw new ArgumentNullException(nameof(snackbar));
+
+        _createdSubscription = _hubConnection.RegisterInvoiceCreated(HandleInvoiceCreated);
+        _paidSubscription = _hubConnection.RegisterInvoicePaid(HandleInvoicePaid);
+    }
+
+    public Task EnsureConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        return _hubConnection.EnsureConnectedAsync(cancellationToken);
+    }
+
+    public IDisposable OnInvoiceCreated(Action<InvoiceCreatedEvent> callback) => Register(_createdHandlers, callback);
+
+    public IDisposable OnInvoicePaid(Action<InvoicePaidEvent> callback) => Register(_paidHandlers, callback);
+
+    private void HandleInvoiceCreated(InvoiceCreatedEvent payload)
+    {
+        _logger.LogInformation("Invoice {InvoiceNumber} created for {CustomerName}.", payload.InvoiceNumber, payload.CustomerName);
+        var formattedTotal = payload.Total.ToString("C", CultureInfo.CurrentCulture);
+        _snackbar.Add($"Invoice {payload.InvoiceNumber} issued · {formattedTotal}", Severity.Info);
+        Notify(_createdHandlers, payload);
+    }
+
+    private void HandleInvoicePaid(InvoicePaidEvent payload)
+    {
+        _logger.LogInformation("Invoice {InvoiceNumber} paid by {CustomerName}.", payload.InvoiceNumber, payload.CustomerName);
+        var isAdmin = _authStateProvider.CurrentUser.IsInRole(RolePolicies.Admin);
+        var message = isAdmin
+            ? $"Invoice #{payload.InvoiceNumber} just paid"
+            : $"Payment received for invoice #{payload.InvoiceNumber}";
+        _snackbar.Add(message, Severity.Success);
+        Notify(_paidHandlers, payload);
+    }
+
+    private static IDisposable Register<T>(ICollection<Action<T>> handlers, Action<T> callback)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static void Notify<T>(ICollection<Action<T>> handlers, T payload)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        Action<T>[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch
+            {
+                // Ignore downstream errors to keep other subscribers alive.
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _createdSubscription.Dispose();
+        _paidSubscription.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _isDisposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _onDispose();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Realtime/RealtimeHubConnection.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Realtime/RealtimeHubConnection.cs
@@ -1,0 +1,521 @@
+// RealtimeHubConnection.cs: Manages the SignalR connection lifecycle and dispatches CRM domain events.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using CRMAdapter.UI.Auth;
+using CRMAdapter.UI.Services.Diagnostics;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Services.Realtime;
+
+/// <summary>
+/// Provides an abstraction for creating hub connection proxies, enabling easier testing.
+/// </summary>
+public interface IHubConnectionProxyFactory
+{
+    /// <summary>Creates a configured hub connection proxy.</summary>
+    /// <param name="options">Options used to configure the underlying connection.</param>
+    /// <returns>The proxy representing the configured hub connection.</returns>
+    IHubConnectionProxy Create(RealtimeHubConnectionOptions options);
+}
+
+/// <summary>
+/// Represents a minimal abstraction over a SignalR hub connection.
+/// </summary>
+public interface IHubConnectionProxy : IAsyncDisposable
+{
+    /// <summary>Gets the current connection state.</summary>
+    HubConnectionState State { get; }
+
+    /// <summary>Occurs when the underlying connection is closed.</summary>
+    event Func<Exception?, Task>? Closed;
+
+    /// <summary>Occurs when the connection transitions into reconnecting state.</summary>
+    event Func<Exception?, Task>? Reconnecting;
+
+    /// <summary>Occurs when the connection successfully re-establishes.</summary>
+    event Func<string?, Task>? Reconnected;
+
+    /// <summary>Starts the connection.</summary>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Stops the connection.</summary>
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Registers a handler for a hub method.</summary>
+    IDisposable On<T>(string methodName, Action<T> handler);
+}
+
+/// <summary>
+/// Options used to construct a hub connection proxy instance.
+/// </summary>
+public sealed class RealtimeHubConnectionOptions
+{
+    /// <summary>Gets or sets the hub URL to connect to.</summary>
+    public required string HubUrl { get; init; }
+
+    /// <summary>Gets or sets the access token provider used for authentication.</summary>
+    public Func<Task<string?>>? AccessTokenProvider { get; init; }
+
+    /// <summary>Gets the collection of headers appended to each connection request.</summary>
+    public IDictionary<string, string> Headers { get; init; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Default factory creating SignalR hub connections with exponential reconnect support.
+/// </summary>
+public sealed class SignalRHubConnectionProxyFactory : IHubConnectionProxyFactory
+{
+    private readonly ILogger<SignalRHubConnectionProxyFactory> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SignalRHubConnectionProxyFactory"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used to record factory diagnostics.</param>
+    public SignalRHubConnectionProxyFactory(ILogger<SignalRHubConnectionProxyFactory> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public IHubConnectionProxy Create(RealtimeHubConnectionOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var builder = new HubConnectionBuilder()
+            .WithUrl(options.HubUrl, httpOptions =>
+            {
+                if (options.AccessTokenProvider is not null)
+                {
+                    httpOptions.AccessTokenProvider = async () =>
+                    {
+                        var token = await options.AccessTokenProvider().ConfigureAwait(false);
+                        return token ?? string.Empty;
+                    };
+                }
+
+                foreach (var header in options.Headers)
+                {
+                    httpOptions.Headers[header.Key] = header.Value;
+                }
+            })
+            .WithAutomaticReconnect(new ExponentialBackoffRetryPolicy());
+
+        _logger.LogInformation("Creating SignalR hub connection targeting {HubUrl}.", options.HubUrl);
+        return new SignalRHubConnectionProxy(builder.Build());
+    }
+
+    private sealed class SignalRHubConnectionProxy : IHubConnectionProxy
+    {
+        private readonly HubConnection _connection;
+
+        public SignalRHubConnectionProxy(HubConnection connection)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
+
+        public HubConnectionState State => _connection.State;
+
+        public event Func<Exception?, Task>? Closed
+        {
+            add => _connection.Closed += value;
+            remove => _connection.Closed -= value;
+        }
+
+        public event Func<Exception?, Task>? Reconnecting
+        {
+            add => _connection.Reconnecting += value;
+            remove => _connection.Reconnecting -= value;
+        }
+
+        public event Func<string?, Task>? Reconnected
+        {
+            add => _connection.Reconnected += value;
+            remove => _connection.Reconnected -= value;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken = default) => _connection.StartAsync(cancellationToken);
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => _connection.StopAsync(cancellationToken);
+
+        public IDisposable On<T>(string methodName, Action<T> handler) => _connection.On(methodName, handler);
+
+        public ValueTask DisposeAsync() => _connection.DisposeAsync();
+    }
+
+    private sealed class ExponentialBackoffRetryPolicy : IRetryPolicy
+    {
+        private static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(30);
+
+        public TimeSpan? NextRetryDelay(RetryContext retryContext)
+        {
+            if (retryContext is null)
+            {
+                throw new ArgumentNullException(nameof(retryContext));
+            }
+
+            if (retryContext.PreviousRetryCount >= 6)
+            {
+                return null;
+            }
+
+            var nextDelaySeconds = Math.Pow(2, retryContext.PreviousRetryCount);
+            var delay = TimeSpan.FromSeconds(nextDelaySeconds);
+            return delay < MaxDelay ? delay : MaxDelay;
+        }
+    }
+}
+
+/// <summary>
+/// Manages the lifetime of the CRM real-time hub connection and dispatches strongly typed events to subscribers.
+/// </summary>
+public sealed class RealtimeHubConnection : IAsyncDisposable
+{
+    private const int CircuitBreakerThreshold = 3;
+    private static readonly TimeSpan CircuitOpenDuration = TimeSpan.FromSeconds(45);
+
+    private readonly IHubConnectionProxyFactory _connectionFactory;
+    private readonly IConfiguration _configuration;
+    private readonly AuthStateProvider _authStateProvider;
+    private readonly CorrelationContext _correlationContext;
+    private readonly ILogger<RealtimeHubConnection> _logger;
+    private readonly ISnackbar _snackbar;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private readonly List<IDisposable> _registrations = new();
+    private readonly List<Action<CustomerCreatedEvent>> _customerCreatedHandlers = new();
+    private readonly List<Action<CustomerUpdatedEvent>> _customerUpdatedHandlers = new();
+    private readonly List<Action<InvoiceCreatedEvent>> _invoiceCreatedHandlers = new();
+    private readonly List<Action<InvoicePaidEvent>> _invoicePaidHandlers = new();
+    private readonly List<Action<VehicleAddedEvent>> _vehicleAddedHandlers = new();
+    private readonly List<Action<AppointmentScheduledEvent>> _appointmentScheduledHandlers = new();
+    private readonly List<Action> _reconnectedHandlers = new();
+    private IHubConnectionProxy? _connection;
+    private int _consecutiveFailures;
+    private DateTimeOffset? _circuitOpenUntil;
+    private bool _handlersRegistered;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RealtimeHubConnection"/> class.
+    /// </summary>
+    public RealtimeHubConnection(
+        IHubConnectionProxyFactory connectionFactory,
+        IConfiguration configuration,
+        AuthStateProvider authStateProvider,
+        CorrelationContext correlationContext,
+        ILogger<RealtimeHubConnection> logger,
+        ISnackbar snackbar)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _authStateProvider = authStateProvider ?? throw new ArgumentNullException(nameof(authStateProvider));
+        _correlationContext = correlationContext ?? throw new ArgumentNullException(nameof(correlationContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snackbar = snackbar ?? throw new ArgumentNullException(nameof(snackbar));
+    }
+
+    /// <summary>
+    /// Ensures the hub connection is active. Any failures trigger circuit breaker behaviour to avoid hot loops.
+    /// </summary>
+    public async Task EnsureConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        if (_circuitOpenUntil is { } openUntil && openUntil > DateTimeOffset.UtcNow)
+        {
+            _logger.LogWarning("Realtime hub circuit is open until {OpenUntil}.", openUntil);
+            return;
+        }
+
+        await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await EnsureConnectionInitializedAsync(cancellationToken).ConfigureAwait(false);
+            if (_connection is null)
+            {
+                return;
+            }
+
+            if (_connection.State == HubConnectionState.Connected)
+            {
+                return;
+            }
+
+            await _connection.StartAsync(cancellationToken).ConfigureAwait(false);
+            _consecutiveFailures = 0;
+            _circuitOpenUntil = null;
+            _logger.LogInformation("Realtime hub connection established.");
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _consecutiveFailures++;
+            _logger.LogWarning(ex, "Failed to start realtime hub connection (attempt {Attempt}).", _consecutiveFailures);
+
+            if (_consecutiveFailures >= CircuitBreakerThreshold)
+            {
+                _circuitOpenUntil = DateTimeOffset.UtcNow.Add(CircuitOpenDuration);
+                _snackbar.Add("CRM live data temporarily unavailable. Retrying soon...", Severity.Warning);
+            }
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    /// <summary>Registers a handler for the <see cref="CustomerCreatedEvent"/> payload.</summary>
+    public IDisposable RegisterCustomerCreated(Action<CustomerCreatedEvent> callback) => RegisterHandler(_customerCreatedHandlers, callback);
+
+    /// <summary>Registers a handler for the <see cref="CustomerUpdatedEvent"/> payload.</summary>
+    public IDisposable RegisterCustomerUpdated(Action<CustomerUpdatedEvent> callback) => RegisterHandler(_customerUpdatedHandlers, callback);
+
+    /// <summary>Registers a handler for the <see cref="InvoiceCreatedEvent"/> payload.</summary>
+    public IDisposable RegisterInvoiceCreated(Action<InvoiceCreatedEvent> callback) => RegisterHandler(_invoiceCreatedHandlers, callback);
+
+    /// <summary>Registers a handler for the <see cref="InvoicePaidEvent"/> payload.</summary>
+    public IDisposable RegisterInvoicePaid(Action<InvoicePaidEvent> callback) => RegisterHandler(_invoicePaidHandlers, callback);
+
+    /// <summary>Registers a handler for the <see cref="VehicleAddedEvent"/> payload.</summary>
+    public IDisposable RegisterVehicleAdded(Action<VehicleAddedEvent> callback) => RegisterHandler(_vehicleAddedHandlers, callback);
+
+    /// <summary>Registers a handler for the <see cref="AppointmentScheduledEvent"/> payload.</summary>
+    public IDisposable RegisterAppointmentScheduled(Action<AppointmentScheduledEvent> callback) => RegisterHandler(_appointmentScheduledHandlers, callback);
+
+    /// <summary>Registers a handler invoked when the hub reconnects.</summary>
+    public IDisposable RegisterReconnected(Action callback) => RegisterHandler(_reconnectedHandlers, callback);
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _connectionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_connection is not null)
+            {
+                await _connection.StopAsync().ConfigureAwait(false);
+                foreach (var registration in _registrations)
+                {
+                    registration.Dispose();
+                }
+
+                _registrations.Clear();
+                await _connection.DisposeAsync().ConfigureAwait(false);
+                _connection = null;
+            }
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    private async Task EnsureConnectionInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is not null)
+        {
+            return;
+        }
+
+        var hubUrl = ResolveHubUrl();
+        var options = new RealtimeHubConnectionOptions
+        {
+            HubUrl = hubUrl,
+            AccessTokenProvider = _authStateProvider.GetAccessTokenAsync,
+        };
+        options.Headers[CRMAdapter.Api.Middleware.CorrelationIdMiddleware.CorrelationHeaderName] = _correlationContext.CurrentCorrelationId;
+
+        _connection = _connectionFactory.Create(options);
+        RegisterConnectionEvents(_connection);
+
+        if (!_handlersRegistered)
+        {
+            RegisterHubHandlers(_connection);
+            _handlersRegistered = true;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private string ResolveHubUrl()
+    {
+        var configuredUrl = _configuration["Realtime:HubUrl"];
+        if (!string.IsNullOrWhiteSpace(configuredUrl))
+        {
+            return configuredUrl.TrimEnd('/');
+        }
+
+        var apiBase = _configuration["Api:BaseUrl"] ?? "https://localhost:5001";
+        return $"{apiBase.TrimEnd('/')}/crmhub";
+    }
+
+    private void RegisterConnectionEvents(IHubConnectionProxy connection)
+    {
+        connection.Reconnected += async _ =>
+        {
+            _logger.LogInformation("Realtime hub connection re-established.");
+            _snackbar.Add("Reconnected to CRM Live Data", Severity.Success);
+            Notify(_reconnectedHandlers);
+            await Task.CompletedTask;
+        };
+
+        connection.Reconnecting += async error =>
+        {
+            if (error is not null)
+            {
+                _logger.LogWarning(error, "Realtime hub reconnecting due to transient error.");
+            }
+            else
+            {
+                _logger.LogInformation("Realtime hub reconnecting.");
+            }
+
+            await Task.CompletedTask;
+        };
+
+        connection.Closed += async error =>
+        {
+            if (error is not null)
+            {
+                _logger.LogWarning(error, "Realtime hub connection closed unexpectedly.");
+            }
+            else
+            {
+                _logger.LogInformation("Realtime hub connection closed.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await EnsureConnectedAsync().ConfigureAwait(false);
+        };
+    }
+
+    private void RegisterHubHandlers(IHubConnectionProxy connection)
+    {
+        _registrations.Add(connection.On<CustomerCreatedEvent>(nameof(ICrmEventsClient.CustomerCreated), payload => Notify(_customerCreatedHandlers, payload)));
+        _registrations.Add(connection.On<CustomerUpdatedEvent>(nameof(ICrmEventsClient.CustomerUpdated), payload => Notify(_customerUpdatedHandlers, payload)));
+        _registrations.Add(connection.On<InvoiceCreatedEvent>(nameof(ICrmEventsClient.InvoiceCreated), payload => Notify(_invoiceCreatedHandlers, payload)));
+        _registrations.Add(connection.On<InvoicePaidEvent>(nameof(ICrmEventsClient.InvoicePaid), payload => Notify(_invoicePaidHandlers, payload)));
+        _registrations.Add(connection.On<VehicleAddedEvent>(nameof(ICrmEventsClient.VehicleAdded), payload => Notify(_vehicleAddedHandlers, payload)));
+        _registrations.Add(connection.On<AppointmentScheduledEvent>(nameof(ICrmEventsClient.AppointmentScheduled), payload => Notify(_appointmentScheduledHandlers, payload)));
+    }
+    private static IDisposable RegisterHandler<T>(ICollection<Action<T>> handlers, Action<T> callback)
+    {
+        if (handlers is null)
+        {
+            throw new ArgumentNullException(nameof(handlers));
+        }
+
+        if (callback is null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static IDisposable RegisterHandler(ICollection<Action> handlers, Action callback)
+    {
+        if (handlers is null)
+        {
+            throw new ArgumentNullException(nameof(handlers));
+        }
+
+        if (callback is null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static void Notify<T>(ICollection<Action<T>> handlers, T payload)
+    {
+        Action<T>[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch
+            {
+                // Intentionally swallow to prevent one subscriber from crashing others.
+            }
+        }
+    }
+
+    private static void Notify(ICollection<Action> handlers)
+    {
+        Action[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler();
+            }
+            catch
+            {
+                // Ignore callback failures to preserve stability.
+            }
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _disposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _onDispose();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Services/Realtime/VehicleRealtimeService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Realtime/VehicleRealtimeService.cs
@@ -1,0 +1,118 @@
+// VehicleRealtimeService.cs: Coordinates vehicle-related realtime notifications.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace CRMAdapter.UI.Services.Realtime;
+
+/// <summary>
+/// Publishes vehicle addition events to interested components.
+/// </summary>
+public sealed class VehicleRealtimeService : IAsyncDisposable
+{
+    private readonly RealtimeHubConnection _hubConnection;
+    private readonly ILogger<VehicleRealtimeService> _logger;
+    private readonly ISnackbar _snackbar;
+    private readonly List<Action<VehicleAddedEvent>> _vehicleHandlers = new();
+    private readonly IDisposable _vehicleSubscription;
+
+    public VehicleRealtimeService(
+        RealtimeHubConnection hubConnection,
+        ILogger<VehicleRealtimeService> logger,
+        ISnackbar snackbar)
+    {
+        _hubConnection = hubConnection ?? throw new ArgumentNullException(nameof(hubConnection));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snackbar = snackbar ?? throw new ArgumentNullException(nameof(snackbar));
+
+        _vehicleSubscription = _hubConnection.RegisterVehicleAdded(HandleVehicleAdded);
+    }
+
+    public Task EnsureConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        return _hubConnection.EnsureConnectedAsync(cancellationToken);
+    }
+
+    public IDisposable OnVehicleAdded(Action<VehicleAddedEvent> callback) => Register(_vehicleHandlers, callback);
+
+    private void HandleVehicleAdded(VehicleAddedEvent payload)
+    {
+        _logger.LogInformation("Vehicle {Vin} added for {CustomerName}.", payload.Vin, payload.CustomerName);
+        _snackbar.Add($"Vehicle {payload.Vin} added for {payload.CustomerName}", Severity.Info);
+        Notify(_vehicleHandlers, payload);
+    }
+
+    private static IDisposable Register<T>(ICollection<Action<T>> handlers, Action<T> callback)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        lock (handlers)
+        {
+            handlers.Add(callback);
+        }
+
+        return new Subscription(() =>
+        {
+            lock (handlers)
+            {
+                handlers.Remove(callback);
+            }
+        });
+    }
+
+    private static void Notify<T>(ICollection<Action<T>> handlers, T payload)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        Action<T>[] snapshot;
+        lock (handlers)
+        {
+            snapshot = handlers.ToArray();
+        }
+
+        foreach (var handler in snapshot)
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch
+            {
+                // Ignore downstream errors to keep other subscribers alive.
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _vehicleSubscription.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _isDisposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _onDispose();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/_Imports.razor
+++ b/CRMAdapter/CRMAdapter.UI/_Imports.razor
@@ -27,3 +27,4 @@
 @using CRMAdapter.UI.Services.Dashboard.Models
 @using CRMAdapter.UI.Components.Dashboard
 @using CRMAdapter.UI.Components
+@using CRMAdapter.CommonContracts.Realtime

--- a/CRMAdapter/CRMAdapter.UI/appsettings.Development.json
+++ b/CRMAdapter/CRMAdapter.UI/appsettings.Development.json
@@ -14,5 +14,8 @@
   },
   "Api": {
     "BaseUrl": "https://localhost:5001"
+  },
+  "Realtime": {
+    "HubUrl": "https://localhost:5001/crmhub"
   }
 }

--- a/CRMAdapter/CommonContracts/Realtime/CrmRealtimeEvents.cs
+++ b/CRMAdapter/CommonContracts/Realtime/CrmRealtimeEvents.cs
@@ -1,0 +1,116 @@
+// CrmRealtimeEvents.cs: Shared event payload contracts for SignalR real-time broadcasting.
+using System;
+
+namespace CRMAdapter.CommonContracts.Realtime;
+
+/// <summary>
+/// Represents a newly created customer summary pushed to listening clients.
+/// </summary>
+/// <param name="Id">Unique identifier of the customer.</param>
+/// <param name="Name">Display name for the customer record.</param>
+/// <param name="Phone">Primary phone number.</param>
+/// <param name="Email">Primary email address.</param>
+/// <param name="VehicleCount">Number of associated vehicles.</param>
+/// <param name="LastInvoiceDate">Date of the most recent invoice for the customer.</param>
+public sealed record CustomerCreatedEvent(
+    Guid Id,
+    string Name,
+    string Phone,
+    string Email,
+    int VehicleCount,
+    DateTime? LastInvoiceDate);
+
+/// <summary>
+/// Represents an updated customer snapshot pushed to listening clients.
+/// </summary>
+/// <param name="Id">Unique identifier of the customer.</param>
+/// <param name="Name">Display name for the customer record.</param>
+/// <param name="Phone">Primary phone number.</param>
+/// <param name="Email">Primary email address.</param>
+/// <param name="VehicleCount">Number of associated vehicles.</param>
+/// <param name="LastInvoiceDate">Date of the most recent invoice for the customer.</param>
+public sealed record CustomerUpdatedEvent(
+    Guid Id,
+    string Name,
+    string Phone,
+    string Email,
+    int VehicleCount,
+    DateTime? LastInvoiceDate);
+
+/// <summary>
+/// Represents a newly created invoice broadcast to connected dashboards.
+/// </summary>
+/// <param name="Id">Unique identifier of the invoice.</param>
+/// <param name="InvoiceNumber">Human-friendly invoice number.</param>
+/// <param name="CustomerId">Identifier of the associated customer.</param>
+/// <param name="CustomerName">Customer name for display.</param>
+/// <param name="VehicleId">Identifier of the related vehicle.</param>
+/// <param name="VehicleVin">Vehicle VIN for quick reference.</param>
+/// <param name="IssuedOn">Issued date/time in UTC.</param>
+/// <param name="Status">Current invoice status.</param>
+/// <param name="Total">Total invoice amount.</param>
+/// <param name="BalanceDue">Outstanding balance remaining.</param>
+public sealed record InvoiceCreatedEvent(
+    Guid Id,
+    string InvoiceNumber,
+    Guid CustomerId,
+    string CustomerName,
+    Guid VehicleId,
+    string VehicleVin,
+    DateTime IssuedOn,
+    string Status,
+    decimal Total,
+    decimal BalanceDue);
+
+/// <summary>
+/// Represents an invoice payment notification payload.
+/// </summary>
+/// <param name="Id">Identifier of the invoice that was paid.</param>
+/// <param name="InvoiceNumber">Display invoice number.</param>
+/// <param name="CustomerId">Identifier of the related customer.</param>
+/// <param name="CustomerName">Name of the customer associated with the invoice.</param>
+/// <param name="AmountPaid">Amount applied to the invoice.</param>
+/// <param name="PaidOn">Date and time the payment was recorded in UTC.</param>
+public sealed record InvoicePaidEvent(
+    Guid Id,
+    string InvoiceNumber,
+    Guid CustomerId,
+    string CustomerName,
+    decimal AmountPaid,
+    DateTime PaidOn);
+
+/// <summary>
+/// Represents a newly added vehicle associated with a customer.
+/// </summary>
+/// <param name="Id">Identifier of the vehicle record.</param>
+/// <param name="CustomerId">Identifier of the vehicle owner.</param>
+/// <param name="CustomerName">Display name for the owner.</param>
+/// <param name="Vin">Vehicle VIN.</param>
+/// <param name="Make">Vehicle manufacturer.</param>
+/// <param name="Model">Vehicle model.</param>
+/// <param name="Year">Model year.</param>
+public sealed record VehicleAddedEvent(
+    Guid Id,
+    Guid CustomerId,
+    string CustomerName,
+    string Vin,
+    string Make,
+    string Model,
+    int Year);
+
+/// <summary>
+/// Represents a scheduled appointment broadcast to service teams.
+/// </summary>
+/// <param name="Id">Identifier of the appointment.</param>
+/// <param name="CustomerId">Identifier of the customer.</param>
+/// <param name="CustomerName">Customer name for the appointment.</param>
+/// <param name="ScheduledFor">Scheduled date/time in UTC.</param>
+/// <param name="ServiceAdvisor">Name of the assigned service advisor.</param>
+/// <param name="Reason">Optional description of the appointment reason.</param>
+public sealed record AppointmentScheduledEvent(
+    Guid Id,
+    Guid CustomerId,
+    string CustomerName,
+    DateTime ScheduledFor,
+    string ServiceAdvisor,
+    string? Reason);

--- a/CRMAdapter/Docs/Realtime.md
+++ b/CRMAdapter/Docs/Realtime.md
@@ -1,0 +1,49 @@
+# Real-time SignalR Integration
+
+The CRM Adapter now provides live CRM updates using SignalR between the API and the Blazor UI. This document outlines how to run the hub, configure clients, and reason about the connection lifecycle.
+
+## Running the API hub
+
+1. Navigate to the API project and launch it as normal:
+   ```bash
+   cd CRMAdapter/CRMAdapter.Api
+   dotnet run
+   ```
+2. The SignalR hub is hosted at `/crmhub` on the API. Ensure HTTPS is enabled (default for the project).
+3. The hub requires JWT authentication with the same roles enforced across the rest of the API. The accepted roles are `Admin`, `Manager`, `Clerk`, and `Tech`.
+
+## Dispatching events from the API
+
+* `CRMAdapter.Api/Hubs/CrmEventsHub.cs` exposes the strongly typed `ICrmEventsClient` interface.
+* Adapters publish events through `CRMAdapter.Api/Events/EventDispatcher.cs`. After resolving the hub context, it broadcasts the event and includes the current correlation identifier.
+* To broadcast a new event from server logic, call one of the dispatcher methods, e.g. `await EventDispatcher.BroadcastCustomerCreatedAsync(payload);`.
+
+## Blazor UI integration
+
+* `CRMAdapter.UI/Services/Realtime/RealtimeHubConnection.cs` encapsulates the SignalR `HubConnection`.
+  * It automatically reconnects with exponential backoff, emits snackbars on reconnection, and opens a circuit breaker after repeated failures.
+  * The hub URL is read from configuration (`Realtime:HubUrl`). In development it defaults to `https://localhost:5001/crmhub`.
+* Specialized scoped services (`CustomerRealtimeService`, `InvoiceRealtimeService`, `VehicleRealtimeService`, and `AppointmentRealtimeService`) expose typed C# callbacks and user-facing toasts.
+* Pages subscribe to these services for instant UI updates:
+  * Customers list performs slide-in and highlight animations for new/updated rows.
+  * Invoices list updates status, balance, and triggers success snackbars for payments.
+  * Dashboard refreshes KPI data whenever any event fires.
+
+## Configuration
+
+* Update `CRMAdapter.UI/appsettings.Development.json` if the API hub URL changes.
+* The UI uses the current JWT session when connecting to the hub. Make sure users authenticate before establishing the realtime connection.
+
+## Testing the flow
+
+1. Start both the API and UI projects.
+2. Sign in to the UI to acquire a JWT token.
+3. Perform an action that emits an event (e.g., create a customer via the API). The Customers page should update immediately with a slide-in animation.
+4. Trigger an invoice payment; the Invoices page should mark the row as paid and display a toast.
+5. Temporarily stop the API; the UI will show a warning toast after the circuit breaker opens. Restarting the API should trigger a "Reconnected" snackbar across active sessions.
+
+## Troubleshooting
+
+* If the connection does not start, check the browser console/server logs for authentication errors.
+* Ensure the SignalR hub endpoint is reachable over HTTPS and the client is configured with the correct base URL.
+* When modifying hub contracts, update both the server interfaces and the UI event payload records located under `CommonContracts/Realtime`.

--- a/CRMAdapter/Tests/CRMAdapter.UI.Tests/Realtime/RealtimeHubTests.cs
+++ b/CRMAdapter/Tests/CRMAdapter.UI.Tests/Realtime/RealtimeHubTests.cs
@@ -1,0 +1,194 @@
+// RealtimeHubTests.cs: Validates realtime connection lifecycle and event dispatch behaviour.
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonContracts.Realtime;
+using CRMAdapter.UI.Auth;
+using CRMAdapter.UI.Services.Diagnostics;
+using CRMAdapter.UI.Services.Realtime;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace CRMAdapter.UI.Tests.Realtime;
+
+public sealed class RealtimeHubTests
+{
+    [Fact]
+    public async Task EnsureConnectedAsync_StartsConnectionAndRegistersHandlers()
+    {
+        var factory = new FakeHubConnectionProxyFactory();
+        var snackbar = new SnackbarService();
+        var connection = CreateConnection(factory, snackbar);
+
+        await connection.EnsureConnectedAsync();
+
+        factory.Proxy.Should().NotBeNull();
+        factory.Proxy!.StartCount.Should().Be(1);
+        factory.Proxy.RegisteredMethods.Should().Contain(nameof(ICrmEventsClient.CustomerCreated));
+        factory.Proxy.RegisteredMethods.Should().Contain(nameof(ICrmEventsClient.InvoicePaid));
+    }
+
+    [Fact]
+    public async Task CustomerCreatedEvent_InvokesRegisteredServiceCallback()
+    {
+        var factory = new FakeHubConnectionProxyFactory();
+        var snackbar = new SnackbarService();
+        var connection = CreateConnection(factory, snackbar);
+        await connection.EnsureConnectedAsync();
+
+        var service = new CustomerRealtimeService(connection, NullLogger<CustomerRealtimeService>.Instance, snackbar);
+        await service.EnsureConnectedAsync();
+
+        var invoked = false;
+        using var subscription = service.OnCustomerCreated(_ => invoked = true);
+
+        var payload = new CustomerCreatedEvent(Guid.NewGuid(), "Jane Doe", "555-0000", "jane@example.com", 1, DateTime.UtcNow);
+        factory.Proxy!.Raise(nameof(ICrmEventsClient.CustomerCreated), payload);
+
+        invoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ReconnectedEvent_EmitsSnackbarAndCallback()
+    {
+        var factory = new FakeHubConnectionProxyFactory();
+        var snackbar = new SnackbarService();
+        var connection = CreateConnection(factory, snackbar);
+        var reconnectedCalled = false;
+        using var subscription = connection.RegisterReconnected(() => reconnectedCalled = true);
+
+        await connection.EnsureConnectedAsync();
+        await factory.Proxy!.TriggerReconnectedAsync();
+
+        reconnectedCalled.Should().BeTrue();
+        snackbar.ShownSnackbars.Should().Contain(snack => snack.Message.Contains("Reconnected to CRM Live Data"));
+    }
+
+    private static RealtimeHubConnection CreateConnection(FakeHubConnectionProxyFactory factory, ISnackbar snackbar)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Realtime:HubUrl"] = "https://localhost/crmhub",
+            })
+            .Build();
+
+        var authProvider = CreateAuthStateProvider();
+        var correlation = new CorrelationContext();
+        return new RealtimeHubConnection(factory, configuration, authProvider, correlation, NullLogger<RealtimeHubConnection>.Instance, snackbar);
+    }
+
+    private static AuthStateProvider CreateAuthStateProvider()
+    {
+        var provider = (AuthStateProvider)FormatterServices.GetUninitializedObject(typeof(AuthStateProvider));
+        typeof(AuthStateProvider).GetField("_sessionStorage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(provider, null);
+        typeof(AuthStateProvider).GetField("_jwtAuthProvider", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(provider, null);
+        typeof(AuthStateProvider).GetField("_logger", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(provider, NullLogger<AuthStateProvider>.Instance);
+        typeof(AuthStateProvider).GetField("_currentUser", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(provider, new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity()));
+        return provider;
+    }
+
+    private sealed class FakeHubConnectionProxyFactory : IHubConnectionProxyFactory
+    {
+        public FakeHubConnectionProxy? Proxy { get; private set; }
+
+        public IHubConnectionProxy Create(RealtimeHubConnectionOptions options)
+        {
+            Proxy = new FakeHubConnectionProxy();
+            return Proxy;
+        }
+    }
+
+    private sealed class FakeHubConnectionProxy : IHubConnectionProxy
+    {
+        private readonly Dictionary<string, List<Action<object>>> _handlers = new();
+
+        public int StartCount { get; private set; }
+
+        public IList<string> RegisteredMethods { get; } = new List<string>();
+
+        public HubConnectionState State { get; private set; } = HubConnectionState.Disconnected;
+
+        public event Func<Exception?, Task>? Closed;
+        public event Func<Exception?, Task>? Reconnecting;
+        public event Func<string?, Task>? Reconnected;
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            StartCount++;
+            State = HubConnectionState.Connected;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            State = HubConnectionState.Disconnected;
+            return Task.CompletedTask;
+        }
+
+        public IDisposable On<T>(string methodName, Action<T> handler)
+        {
+            RegisteredMethods.Add(methodName);
+            if (!_handlers.TryGetValue(methodName, out var list))
+            {
+                list = new List<Action<object>>();
+                _handlers[methodName] = list;
+            }
+
+            Action<object> wrapped = obj => handler((T)obj);
+            list.Add(wrapped);
+            return new Subscription(() => list.Remove(wrapped));
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void Raise<T>(string methodName, T payload)
+        {
+            if (_handlers.TryGetValue(methodName, out var list))
+            {
+                foreach (var handler in list.ToArray())
+                {
+                    handler(payload!);
+                }
+            }
+        }
+
+        public Task TriggerReconnectedAsync()
+        {
+            return Reconnected is null ? Task.CompletedTask : Reconnected.Invoke("reconnected");
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _disposed;
+
+        public Subscription(Action onDispose)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _onDispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a secure SignalR hub and event dispatcher so API adapters can broadcast CRM events
- wire a resilient realtime connection into the Blazor UI with scoped domain services and animations
- refresh key pages (Customers, Invoices, Dashboard) on live events and document the new setup

## Testing
- dotnet test *(fails: dotnet CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4489cc8fc832fb0db6b918eec1857