### PR TITLE
feat: add offline-first cache and sync pipeline

### DIFF
--- a/CRMAdapter/CRMAdapter.UI/Core/Storage/FileSystemCache.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Storage/FileSystemCache.cs
@@ -1,0 +1,132 @@
+// FileSystemCache.cs: Stores offline cache artifacts on disk for desktop/server hosted Blazor scenarios.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.UI.Core.Storage;
+
+/// <summary>
+/// File-backed implementation of <see cref="ILocalCache"/> that persists JSON payloads per entity type.
+/// </summary>
+public sealed class FileSystemCache : ILocalCache
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly string _rootPath;
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+    public FileSystemCache(string rootPath)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+        {
+            throw new ArgumentException("Cache root path must be supplied.", nameof(rootPath));
+        }
+
+        _rootPath = rootPath;
+        Directory.CreateDirectory(_rootPath);
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var map = await ReadAllAsync<T>(cancellationToken).ConfigureAwait(false);
+        return map.TryGetValue(key, out var value) ? value : default;
+    }
+
+    public async Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var map = await ReadAllAsync<T>(cancellationToken).ConfigureAwait(false);
+        map[key] = value!;
+        await WriteAllAsync(map, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var map = await ReadAllAsync<T>(cancellationToken).ConfigureAwait(false);
+        if (map.Remove(key))
+        {
+            await WriteAllAsync(map, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<IReadOnlyList<T>> GetAllAsync<T>(CancellationToken cancellationToken = default)
+    {
+        var map = await ReadAllAsync<T>(cancellationToken).ConfigureAwait(false);
+        return new List<T>(map.Values);
+    }
+
+    private string GetPath<T>()
+    {
+        var typeName = typeof(T).FullName ?? typeof(T).Name;
+        var safeName = typeName.Replace('<', '_').Replace('>', '_').Replace(':', '_').Replace('/', '_');
+        return Path.Combine(_rootPath, safeName + ".json");
+    }
+
+    private SemaphoreSlim GetLock<T>()
+    {
+        var key = typeof(T).FullName ?? typeof(T).Name;
+        return _locks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+    }
+
+    private async Task<Dictionary<string, T>> ReadAllAsync<T>(CancellationToken cancellationToken)
+    {
+        var filePath = GetPath<T>();
+        var gate = GetLock<T>();
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                return new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            await using var stream = File.OpenRead(filePath);
+            var payload = await JsonSerializer.DeserializeAsync<Dictionary<string, T>>(stream, SerializerOptions, cancellationToken)
+                .ConfigureAwait(false);
+            return payload ?? new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task WriteAllAsync<T>(Dictionary<string, T> items, CancellationToken cancellationToken)
+    {
+        var filePath = GetPath<T>();
+        var gate = GetLock<T>();
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            await using var stream = File.Create(filePath);
+            await JsonSerializer.SerializeAsync(stream, items, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Storage/ILocalCache.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Storage/ILocalCache.cs
@@ -1,0 +1,32 @@
+// ILocalCache.cs: Abstraction over platform-specific persistence for offline-ready data and sync queues.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.UI.Core.Storage;
+
+/// <summary>
+/// Provides lightweight CRUD semantics over a local persistence mechanism (IndexedDB, filesystem, etc.).
+/// </summary>
+public interface ILocalCache
+{
+    /// <summary>
+    /// Retrieves an item previously stored for the specified type and key.
+    /// </summary>
+    Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the supplied item for later retrieval.
+    /// </summary>
+    Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the cached entry if it exists.
+    /// </summary>
+    Task DeleteAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all cached entries for the specified type.
+    /// </summary>
+    Task<IReadOnlyList<T>> GetAllAsync<T>(CancellationToken cancellationToken = default);
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Storage/IndexedDbCache.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Storage/IndexedDbCache.cs
@@ -1,0 +1,108 @@
+// IndexedDbCache.cs: IndexedDB-backed cache implementation for offline support in browser-hosted Blazor.
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace CRMAdapter.UI.Core.Storage;
+
+/// <summary>
+/// Implements <see cref="ILocalCache"/> via IndexedDB using a small JS helper shim.
+/// </summary>
+public sealed class IndexedDbCache : ILocalCache, IAsyncDisposable
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
+
+    public IndexedDbCache(IJSRuntime jsRuntime)
+    {
+        if (jsRuntime is null)
+        {
+            throw new ArgumentNullException(nameof(jsRuntime));
+        }
+
+        _moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./js/offlineCache.js").AsTask());
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        var json = await module.InvokeAsync<string?>("getEntry", cancellationToken, GetTypeKey<T>(), key);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize<T>(json, SerializerOptions);
+    }
+
+    public async Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        var json = JsonSerializer.Serialize(value, SerializerOptions);
+        await module.InvokeVoidAsync("setEntry", cancellationToken, GetTypeKey<T>(), key, json);
+    }
+
+    public async Task DeleteAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Cache key must be supplied.", nameof(key));
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("deleteEntry", cancellationToken, GetTypeKey<T>(), key);
+    }
+
+    public async Task<IReadOnlyList<T>> GetAllAsync<T>(CancellationToken cancellationToken = default)
+    {
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        var jsonItems = await module.InvokeAsync<string[]>("getAllEntries", cancellationToken, GetTypeKey<T>());
+        var list = new List<T>(jsonItems.Length);
+        foreach (var json in jsonItems)
+        {
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                var item = JsonSerializer.Deserialize<T>(json, SerializerOptions);
+                if (item is not null)
+                {
+                    list.Add(item);
+                }
+            }
+        }
+
+        return list;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_moduleTask.IsValueCreated)
+        {
+            var module = await _moduleTask.Value.ConfigureAwait(false);
+            await module.DisposeAsync();
+        }
+    }
+
+    private static string GetTypeKey<T>()
+    {
+        return typeof(T).FullName ?? typeof(T).Name;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/BackgroundSyncWorker.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/BackgroundSyncWorker.cs
@@ -1,0 +1,235 @@
+// BackgroundSyncWorker.cs: Periodically flushes the offline queue to the CRM API.
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Services.Appointments.Models;
+using CRMAdapter.UI.Services.Customers.Models;
+using CRMAdapter.UI.Services.Invoices.Models;
+using CRMAdapter.UI.Services.Vehicles.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class BackgroundSyncWorker : BackgroundService
+{
+    private readonly ISyncQueue _syncQueue;
+    private readonly IChangeDispatcher _dispatcher;
+    private readonly OfflineSyncState _state;
+    private readonly OfflineSyncOptions _options;
+    private readonly ILogger<BackgroundSyncWorker> _logger;
+    private readonly ILocalCache _cache;
+    private static readonly JsonSerializerOptions PayloadSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public BackgroundSyncWorker(
+        ISyncQueue syncQueue,
+        IChangeDispatcher dispatcher,
+        OfflineSyncState state,
+        ILocalCache cache,
+        IOptions<OfflineSyncOptions> options,
+        ILogger<BackgroundSyncWorker> logger)
+    {
+        _syncQueue = syncQueue ?? throw new ArgumentNullException(nameof(syncQueue));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        var pending = await _syncQueue.DequeueAllAsync(cancellationToken).ConfigureAwait(false);
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        _state.SetSyncing(true);
+        try
+        {
+            foreach (var change in pending)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var result = await _dispatcher.DispatchAsync(change, cancellationToken).ConfigureAwait(false);
+                if (result.Success)
+                {
+                    await _syncQueue.MarkSyncedAsync(change.CorrelationId, cancellationToken).ConfigureAwait(false);
+                    if (result.ServerTimestamp.HasValue)
+                    {
+                        _state.MarkSuccessfulSync(result.ServerTimestamp.Value);
+                    }
+                    else
+                    {
+                        _state.MarkSuccessfulSync(DateTimeOffset.UtcNow);
+                    }
+                }
+                else if (result.Conflict)
+                {
+                    await _syncQueue.MarkSyncedAsync(change.CorrelationId, cancellationToken).ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(result.ServerPayload))
+                    {
+                        await ApplyServerPayloadAsync(change, result.ServerPayload!, cancellationToken).ConfigureAwait(false);
+                    }
+                    _state.ReportConflict(new SyncConflictNotification(change.EntityType, change.EntityId, result.FailureReason ?? "Conflict detected."));
+                    _state.MarkSuccessfulSync(result.ServerTimestamp ?? DateTimeOffset.UtcNow);
+                }
+                else
+                {
+                    _logger.LogWarning("Stopping sync flush early due to failure: {Reason}", result.FailureReason);
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            _state.SetSyncing(false);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Offline sync worker disabled via configuration.");
+            return;
+        }
+
+        var interval = TimeSpan.FromSeconds(Math.Max(5, _options.IntervalSeconds));
+        _logger.LogInformation("Offline sync worker started with interval {Interval}.", interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!_state.IsOffline)
+                {
+                    await FlushAsync(stoppingToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while flushing offline queue.");
+            }
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("Offline sync worker stopped.");
+    }
+
+    private async Task ApplyServerPayloadAsync(ChangeEnvelope change, string payload, CancellationToken cancellationToken)
+    {
+        try
+        {
+            switch (change.EntityType)
+            {
+                case "Customers":
+                    var customer = JsonSerializer.Deserialize<CustomerDetail>(payload, PayloadSerializerOptions);
+                    if (customer is not null)
+                    {
+                        await _cache.SetAsync(customer.Id.ToString(), customer, cancellationToken).ConfigureAwait(false);
+                        var summary = new CustomerSummary(
+                            customer.Id,
+                            customer.Name,
+                            customer.Phone,
+                            customer.Email,
+                            customer.Vehicles.Count,
+                            customer.Invoices.OrderByDescending(invoice => invoice.IssuedOn).FirstOrDefault()?.IssuedOn);
+                        await _cache.SetAsync(summary.Id.ToString(), summary, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+                case "Vehicles":
+                    var vehicle = JsonSerializer.Deserialize<VehicleDetail>(payload, PayloadSerializerOptions);
+                    if (vehicle is not null)
+                    {
+                        await _cache.SetAsync(vehicle.Id.ToString(), vehicle, cancellationToken).ConfigureAwait(false);
+                        var vehicleSummary = new VehicleSummary(
+                            vehicle.Id,
+                            vehicle.Vin,
+                            vehicle.Year,
+                            vehicle.Make,
+                            vehicle.Model,
+                            vehicle.Owner.Id,
+                            vehicle.Owner.Name,
+                            vehicle.Plate,
+                            vehicle.Status,
+                            vehicle.LastServiceDate);
+                        await _cache.SetAsync(vehicleSummary.Id.ToString(), vehicleSummary, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+                case "Invoices":
+                    var invoice = JsonSerializer.Deserialize<InvoiceDetail>(payload, PayloadSerializerOptions);
+                    if (invoice is not null)
+                    {
+                        await _cache.SetAsync(invoice.Id.ToString(), invoice, cancellationToken).ConfigureAwait(false);
+                        var invoiceSummary = new InvoiceSummary(
+                            invoice.Id,
+                            invoice.InvoiceNumber,
+                            invoice.Customer.Id,
+                            invoice.Customer.Name,
+                            invoice.Vehicle.Id,
+                            invoice.Vehicle.Vin,
+                            invoice.IssuedOn,
+                            invoice.Status,
+                            invoice.Total,
+                            invoice.BalanceDue);
+                        await _cache.SetAsync(invoiceSummary.Id.ToString(), invoiceSummary, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+                case "Appointments":
+                    var appointment = JsonSerializer.Deserialize<AppointmentDetail>(payload, PayloadSerializerOptions);
+                    if (appointment is not null)
+                    {
+                        await _cache.SetAsync(appointment.Id.ToString(), appointment, cancellationToken).ConfigureAwait(false);
+                        var appointmentSummary = BuildAppointmentSummary(appointment);
+                        await _cache.SetAsync(appointmentSummary.Id.ToString(), appointmentSummary, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to hydrate server payload for {EntityType} {EntityId}.", change.EntityType, change.EntityId);
+        }
+    }
+
+    private static AppointmentSummary BuildAppointmentSummary(AppointmentDetail detail)
+    {
+        var notesPreview = string.IsNullOrWhiteSpace(detail.Notes)
+            ? null
+            : detail.Notes.Length > 120
+                ? detail.Notes[..120] + "…"
+                : detail.Notes;
+
+        return new AppointmentSummary(
+            detail.Id,
+            detail.AppointmentNumber,
+            detail.ScheduledStart,
+            detail.ScheduledEnd,
+            detail.Status,
+            detail.Service,
+            detail.Technician,
+            detail.Customer,
+            detail.Vehicle,
+            notesPreview);
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeDispatchResult.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeDispatchResult.cs
@@ -1,0 +1,16 @@
+// ChangeDispatchResult.cs: Captures the outcome of attempting to replay an offline change.
+using System;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed record ChangeDispatchResult(bool Success, bool Conflict, DateTimeOffset? ServerTimestamp = null, string? ServerPayload = null, string? FailureReason = null)
+{
+    public static ChangeDispatchResult Successful(DateTimeOffset? serverTimestamp = null, string? serverPayload = null)
+        => new(true, false, serverTimestamp, serverPayload, null);
+
+    public static ChangeDispatchResult ConflictDetected(DateTimeOffset? serverTimestamp, string? serverPayload, string? reason)
+        => new(false, true, serverTimestamp, serverPayload, reason);
+
+    public static ChangeDispatchResult Failed(string? reason)
+        => new(false, false, null, null, reason);
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeDispatcher.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeDispatcher.cs
@@ -1,0 +1,124 @@
+// ChangeDispatcher.cs: Default implementation that replays queued changes against the CRM API.
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Infrastructure.Security;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class ChangeDispatcher : IChangeDispatcher
+{
+    private static readonly IReadOnlyDictionary<string, string> EntityRoutes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Customers"] = "customers",
+        ["Vehicles"] = "vehicles",
+        ["Invoices"] = "invoices",
+        ["Appointments"] = "appointments",
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ChangeDispatcher> _logger;
+    private readonly OfflineSyncState _state;
+
+    public ChangeDispatcher(IHttpClientFactory httpClientFactory, ILogger<ChangeDispatcher> logger, OfflineSyncState state)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+    }
+
+    public async Task<ChangeDispatchResult> DispatchAsync(ChangeEnvelope change, CancellationToken cancellationToken)
+    {
+        if (change is null)
+        {
+            throw new ArgumentNullException(nameof(change));
+        }
+
+        if (!EntityRoutes.TryGetValue(change.EntityType, out var route))
+        {
+            _logger.LogWarning("No route mapping exists for entity type {EntityType}. Change {ChangeId} will be dropped.", change.EntityType, change.CorrelationId);
+            return ChangeDispatchResult.Failed("Unknown entity type.");
+        }
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(HttpClientNames.CrmApi);
+            using var request = BuildRequest(change, route);
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                var serverPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var serverTimestamp = TryParseTimestamp(response.Headers);
+                _logger.LogWarning("Conflict detected while replaying change {ChangeId} for {EntityType} {EntityId}.", change.CorrelationId, change.EntityType, change.EntityId);
+                return ChangeDispatchResult.ConflictDetected(serverTimestamp, serverPayload, "Conflict detected by API.");
+            }
+
+            response.EnsureSuccessStatusCode();
+
+            var timestamp = TryParseTimestamp(response.Headers);
+            var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Successfully replayed change {ChangeId} for {EntityType} {EntityId}.", change.CorrelationId, change.EntityType, change.EntityId);
+            _state.SetOffline(false);
+            return ChangeDispatchResult.Successful(timestamp, string.IsNullOrWhiteSpace(payload) ? null : payload);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to dispatch change {ChangeId} for {EntityType} {EntityId}.", change.CorrelationId, change.EntityType, change.EntityId);
+            _state.SetOffline(true);
+            return ChangeDispatchResult.Failed(ex.Message);
+        }
+    }
+
+    private static HttpRequestMessage BuildRequest(ChangeEnvelope change, string route)
+    {
+        var uri = route.TrimEnd('/');
+        if (change.Operation != ChangeOperation.Create)
+        {
+            uri += "/" + change.EntityId;
+        }
+
+        HttpMethod method = change.Operation switch
+        {
+            ChangeOperation.Create => HttpMethod.Post,
+            ChangeOperation.Update => HttpMethod.Put,
+            ChangeOperation.Delete => HttpMethod.Delete,
+            _ => HttpMethod.Post,
+        };
+
+        var request = new HttpRequestMessage(method, uri);
+        if (change.Operation != ChangeOperation.Delete && !string.IsNullOrWhiteSpace(change.Payload))
+        {
+            request.Content = new StringContent(change.Payload!, Encoding.UTF8, "application/json");
+        }
+
+        return request;
+    }
+
+    private static DateTimeOffset? TryParseTimestamp(HttpResponseHeaders headers)
+    {
+        if (headers is null)
+        {
+            return null;
+        }
+
+        if (headers.TryGetValues("X-Server-Timestamp", out var values))
+        {
+            foreach (var value in values)
+            {
+                if (DateTimeOffset.TryParse(value, out var timestamp))
+                {
+                    return timestamp;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeEnvelope.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeEnvelope.cs
@@ -1,0 +1,62 @@
+// ChangeEnvelope.cs: Represents a durable offline change pending synchronization.
+using System;
+using System.Text.Json;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class ChangeEnvelope
+{
+    public ChangeEnvelope(
+        string entityType,
+        string entityId,
+        ChangeOperation operation,
+        string? payload,
+        DateTimeOffset timestamp,
+        Guid correlationId)
+    {
+        EntityType = entityType ?? throw new ArgumentNullException(nameof(entityType));
+        EntityId = entityId ?? throw new ArgumentNullException(nameof(entityId));
+        Operation = operation;
+        Payload = payload;
+        Timestamp = timestamp;
+        CorrelationId = correlationId == Guid.Empty ? Guid.NewGuid() : correlationId;
+    }
+
+    public string EntityType { get; }
+
+    public string EntityId { get; }
+
+    public ChangeOperation Operation { get; }
+
+    /// <summary>
+    /// Serialized JSON payload representing the requested mutation.
+    /// </summary>
+    public string? Payload { get; }
+
+    public DateTimeOffset Timestamp { get; }
+
+    public Guid CorrelationId { get; }
+
+    public static ChangeEnvelope ForCreate<T>(string entityType, string entityId, T payload)
+    {
+        return Create(entityType, entityId, ChangeOperation.Create, payload);
+    }
+
+    public static ChangeEnvelope ForUpdate<T>(string entityType, string entityId, T payload)
+    {
+        return Create(entityType, entityId, ChangeOperation.Update, payload);
+    }
+
+    public static ChangeEnvelope ForDelete(string entityType, string entityId)
+    {
+        return new ChangeEnvelope(entityType, entityId, ChangeOperation.Delete, null, DateTimeOffset.UtcNow, Guid.NewGuid());
+    }
+
+    private static ChangeEnvelope Create<T>(string entityType, string entityId, ChangeOperation operation, T payload)
+    {
+        var json = payload is null
+            ? null
+            : JsonSerializer.Serialize(payload, payload.GetType(), new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        return new ChangeEnvelope(entityType, entityId, operation, json, DateTimeOffset.UtcNow, Guid.NewGuid());
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeOperation.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ChangeOperation.cs
@@ -1,0 +1,9 @@
+// ChangeOperation.cs: Enumerates supported offline change types for replay.
+namespace CRMAdapter.UI.Core.Sync;
+
+public enum ChangeOperation
+{
+    Create,
+    Update,
+    Delete
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ConnectivityMonitor.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ConnectivityMonitor.cs
@@ -1,0 +1,52 @@
+// ConnectivityMonitor.cs: Bridges browser online/offline events into the shared sync state.
+using System;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class ConnectivityMonitor : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private readonly OfflineSyncState _state;
+    private DotNetObjectReference<ConnectivityMonitor>? _dotNetRef;
+    private IJSObjectReference? _module;
+
+    public ConnectivityMonitor(IJSRuntime jsRuntime, OfflineSyncState state)
+    {
+        _jsRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+    }
+
+    public async Task InitializeAsync()
+    {
+        _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/offlineCache.js");
+        _dotNetRef ??= DotNetObjectReference.Create(this);
+        await _module.InvokeVoidAsync("registerConnectivity", _dotNetRef);
+    }
+
+    [JSInvokable]
+    public void UpdateOnlineStatus(bool isOnline)
+    {
+        _state.SetOffline(!isOnline);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null)
+        {
+            try
+            {
+                await _module.InvokeVoidAsync("disposeConnectivity");
+            }
+            catch (JSDisconnectedException)
+            {
+                // Ignore: circuit already gone.
+            }
+
+            await _module.DisposeAsync();
+        }
+
+        _dotNetRef?.Dispose();
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/IChangeDispatcher.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/IChangeDispatcher.cs
@@ -1,0 +1,10 @@
+// IChangeDispatcher.cs: Dispatches queued offline changes back to the API when connectivity is restored.
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public interface IChangeDispatcher
+{
+    Task<ChangeDispatchResult> DispatchAsync(ChangeEnvelope change, CancellationToken cancellationToken);
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/ISyncQueue.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/ISyncQueue.cs
@@ -1,0 +1,18 @@
+// ISyncQueue.cs: Coordinates offline mutation persistence and replay.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public interface ISyncQueue
+{
+    Task EnqueueChangeAsync(ChangeEnvelope change, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ChangeEnvelope>> DequeueAllAsync(CancellationToken cancellationToken = default);
+
+    Task MarkSyncedAsync(Guid correlationId, CancellationToken cancellationToken = default);
+
+    Task<int> GetLengthAsync(CancellationToken cancellationToken = default);
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/OfflineSyncOptions.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/OfflineSyncOptions.cs
@@ -1,0 +1,11 @@
+// OfflineSyncOptions.cs: Configuration model controlling background sync behavior.
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class OfflineSyncOptions
+{
+    public const string SectionName = "OfflineSync";
+
+    public bool Enabled { get; set; } = true;
+
+    public int IntervalSeconds { get; set; } = 30;
+}

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/OfflineSyncState.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/OfflineSyncState.cs
@@ -1,0 +1,122 @@
+// OfflineSyncState.cs: Tracks connectivity and sync metrics for UI feedback.
+using System;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class OfflineSyncState
+{
+    private readonly object _gate = new();
+    private bool _isOffline;
+    private bool _isSyncing;
+    private int _queueLength;
+    private DateTimeOffset? _lastSuccessfulSync;
+
+    public event Action? StateChanged;
+    public event Action<SyncConflictNotification>? ConflictDetected;
+
+    public bool IsOffline
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _isOffline;
+            }
+        }
+    }
+
+    public bool IsSyncing
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _isSyncing;
+            }
+        }
+    }
+
+    public int QueueLength
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _queueLength;
+            }
+        }
+    }
+
+    public DateTimeOffset? LastSuccessfulSync
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _lastSuccessfulSync;
+            }
+        }
+    }
+
+    public void SetOffline(bool offline)
+    {
+        lock (_gate)
+        {
+            if (_isOffline == offline)
+            {
+                return;
+            }
+
+            _isOffline = offline;
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void SetQueueLength(int length)
+    {
+        lock (_gate)
+        {
+            _queueLength = length;
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void SetSyncing(bool syncing)
+    {
+        lock (_gate)
+        {
+            if (_isSyncing == syncing)
+            {
+                return;
+            }
+
+            _isSyncing = syncing;
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void MarkSuccessfulSync(DateTimeOffset timestamp)
+    {
+        lock (_gate)
+        {
+            _lastSuccessfulSync = timestamp;
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void ReportConflict(SyncConflictNotification notification)
+    {
+        ConflictDetected?.Invoke(notification);
+    }
+
+    private void NotifyStateChanged()
+    {
+        StateChanged?.Invoke();
+    }
+}
+
+public sealed record SyncConflictNotification(string EntityType, string EntityId, string? Detail);

--- a/CRMAdapter/CRMAdapter.UI/Core/Sync/SyncQueue.cs
+++ b/CRMAdapter/CRMAdapter.UI/Core/Sync/SyncQueue.cs
@@ -1,0 +1,67 @@
+// SyncQueue.cs: Durable offline queue implementation backed by the local cache abstraction.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.UI.Core.Sync;
+
+public sealed class SyncQueue : ISyncQueue
+{
+    private readonly ILocalCache _cache;
+    private readonly OfflineSyncState _state;
+    private readonly ILogger<SyncQueue> _logger;
+
+    public SyncQueue(ILocalCache cache, OfflineSyncState state, ILogger<SyncQueue> logger)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task EnqueueChangeAsync(ChangeEnvelope change, CancellationToken cancellationToken = default)
+    {
+        if (change is null)
+        {
+            throw new ArgumentNullException(nameof(change));
+        }
+
+        _logger.LogInformation("Queuing offline change {ChangeId} for {EntityType} {EntityId} ({Operation}).", change.CorrelationId, change.EntityType, change.EntityId, change.Operation);
+        await _cache.SetAsync(change.CorrelationId.ToString(), change, cancellationToken).ConfigureAwait(false);
+        await UpdateQueueLengthAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ChangeEnvelope>> DequeueAllAsync(CancellationToken cancellationToken = default)
+    {
+        var pending = await _cache.GetAllAsync<ChangeEnvelope>(cancellationToken).ConfigureAwait(false);
+        var ordered = pending.OrderBy(change => change.Timestamp).ToList();
+        _logger.LogDebug("DequeueAll requested. {Count} pending changes discovered.", ordered.Count);
+        return ordered;
+    }
+
+    public async Task MarkSyncedAsync(Guid correlationId, CancellationToken cancellationToken = default)
+    {
+        if (correlationId == Guid.Empty)
+        {
+            return;
+        }
+
+        await _cache.DeleteAsync<ChangeEnvelope>(correlationId.ToString(), cancellationToken).ConfigureAwait(false);
+        await UpdateQueueLengthAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> GetLengthAsync(CancellationToken cancellationToken = default)
+    {
+        var pending = await _cache.GetAllAsync<ChangeEnvelope>(cancellationToken).ConfigureAwait(false);
+        return pending.Count;
+    }
+
+    private async Task UpdateQueueLengthAsync(CancellationToken cancellationToken)
+    {
+        var length = await GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        _state.SetQueueLength(length);
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Docs/OfflineSync.md
+++ b/CRMAdapter/CRMAdapter.UI/Docs/OfflineSync.md
@@ -1,0 +1,50 @@
+# Offline Sync Architecture
+
+The CRM Adapter UI operates in an offline-first mode to ensure the primary entities—customers, vehicles, invoices, and appointments—remain accessible even when the API is unavailable. This document outlines how the local cache, sync queue, and background worker collaborate to provide a seamless experience.
+
+## Local Cache
+
+- **Abstraction**: `ILocalCache` exposes CRUD methods for typed entries. `IndexedDbCache` is used for WebAssembly experiences; `FileSystemCache` backs Blazor Server / desktop deployments.
+- **Structure**: Each entity type is stored in its own logical bucket, keyed by the entity identifier. The cache contains both summaries and detail projections so that list views and drill downs can hydrate instantly.
+- **Updates**: Successful API calls write-through to the cache. When the API is unreachable, the cache is queried directly. Mock data is only used as a last resort if no cache entry exists.
+
+## Sync Queue
+
+- **Envelope**: `ChangeEnvelope` captures entity type, identifier, operation (create/update/delete), serialized payload, and timestamps.
+- **Implementation**: `SyncQueue` persists the envelopes via `ILocalCache`, allowing restarts without losing work.
+- **Enqueue Points**: Service methods enqueue changes whenever API mutations fail. For example, `SaveAppointmentAsync` adds a create/update record if the `POST`/`PUT` call throws `HttpRequestException`.
+
+## Background Sync Worker
+
+- **Configuration**: Controlled through `OfflineSync` in `appsettings.json`. The default interval is 20 seconds with the worker enabled.
+- **Execution**: `BackgroundSyncWorker` retrieves pending changes, dispatches them via `ChangeDispatcher`, and updates `OfflineSyncState` with queue length, sync progress, and last successful time.
+- **Conflicts**: When the API returns `409 Conflict`, the worker applies the “last write wins” policy—server versions are preserved, the queue entry is removed, and a snackbar notification is raised.
+
+## Connectivity & UI Feedback
+
+- `ConnectivityMonitor` listens for browser online/offline events and updates `OfflineSyncState`.
+- `OfflineBanner` shows when the application is offline and reassures users that changes will sync later.
+- `SyncStatus` displays queue length, last sync time, and emits snackbar messages on conflicts.
+
+## Testing Offline Mode
+
+1. Prime the cache by browsing the app while connected.
+2. Stop or block the CRM API.
+3. Refresh entity lists—data loads from the cache.
+4. Perform a mutation (e.g., schedule an appointment). The UI writes to the cache immediately and the queue length increases.
+5. Restore the API. Within the configured interval the background worker replays queued changes. Watch the sync status badge and application logs for confirmation.
+6. Verify real-time updates arrive through SignalR once the API acknowledges the change.
+
+## Conflict Handling
+
+- **Detection**: A `409 Conflict` response marks the change as conflicting.
+- **Resolution**: The server’s payload and timestamp are treated as canonical. The queue entry is removed, the cache is updated with the server version, and the user is informed via snackbar and console log.
+- **Extensibility**: `OfflineSyncState.ReportConflict` provides a hook to replace the simple last-write-wins strategy with richer policies in the future.
+
+## Manual Validation Checklist
+
+- [ ] Run the UI, populate the cache (navigate across entity pages).
+- [ ] Kill the API and confirm cached lists & details remain accessible.
+- [ ] Submit mutations offline; observe the sync queue length growing.
+- [ ] Restore connectivity and confirm queued changes replay automatically.
+- [ ] Review `Docs/OfflineSync.md` for additional troubleshooting guidance.

--- a/CRMAdapter/CRMAdapter.UI/Hosting/ApplicationHost.razor
+++ b/CRMAdapter/CRMAdapter.UI/Hosting/ApplicationHost.razor
@@ -19,6 +19,7 @@
 <body class="app-shell" data-telemetry-scope="crm-adapter-ui">
     <App />
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="js/offlineCache.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/CRMAdapter/CRMAdapter.UI/Services/Api/Appointments/AppointmentApiClient.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Api/Appointments/AppointmentApiClient.cs
@@ -1,24 +1,43 @@
 // AppointmentApiClient.cs: HTTP client facade for appointment operations, currently serving mock data.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
 using CRMAdapter.UI.Services.Api;
 using CRMAdapter.UI.Services.Appointments.Models;
 using CRMAdapter.UI.Services.Contracts;
 using CRMAdapter.UI.Services.Mock.Appointments;
+using Microsoft.Extensions.Logging;
 
 namespace CRMAdapter.UI.Services.Api.Appointments;
 
 public sealed class AppointmentApiClient : BaseApiClient, IAppointmentService
 {
     private readonly InMemoryAppointmentBook _mock;
+    private readonly ILocalCache _cache;
+    private readonly ISyncQueue _syncQueue;
+    private readonly OfflineSyncState _syncState;
+    private readonly ILogger<AppointmentApiClient> _logger;
 
-    public AppointmentApiClient(HttpClient client, InMemoryAppointmentBook mock)
+    public AppointmentApiClient(
+        HttpClient client,
+        InMemoryAppointmentBook mock,
+        ILocalCache cache,
+        ISyncQueue syncQueue,
+        OfflineSyncState syncState,
+        ILogger<AppointmentApiClient> logger)
         : base(client)
     {
         _mock = mock;
+        _cache = cache;
+        _syncQueue = syncQueue;
+        _syncState = syncState;
+        _logger = logger;
     }
 
     public async Task<IReadOnlyList<AppointmentSummary>> GetAppointmentsAsync(
@@ -27,37 +46,255 @@ public sealed class AppointmentApiClient : BaseApiClient, IAppointmentService
         string? status = null,
         CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/appointments query once backend is wired.
-        return await _mock.GetAppointmentsAsync(start, end, status, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var query = BuildRangeQuery(start, end, status);
+            var response = await Client.GetAsync($"appointments{query}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var appointments = await response.Content.ReadFromJsonAsync<List<AppointmentSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<AppointmentSummary>();
+            foreach (var appointment in appointments)
+            {
+                await _cache.SetAsync(appointment.Id.ToString(), appointment, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return appointments;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached appointments due to API failure.");
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAllAsync<AppointmentSummary>(cancellationToken).ConfigureAwait(false);
+            return FilterAppointments(cached, start, end, status);
+        }
     }
 
     public async Task<AppointmentDetail?> GetAppointmentAsync(Guid appointmentId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/appointments/{appointmentId} once backend is wired.
-        return await _mock.GetAppointmentAsync(appointmentId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"appointments/{appointmentId}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var detail = await response.Content.ReadFromJsonAsync<AppointmentDetail>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (detail is not null)
+            {
+                await CacheAppointmentAsync(detail, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return detail;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached appointment {AppointmentId} due to API failure.", appointmentId);
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAsync<AppointmentDetail>(appointmentId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                return cached;
+            }
+
+            return await _mock.GetAppointmentAsync(appointmentId, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task<IReadOnlyList<AppointmentSummary>> GetAppointmentsForCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/customers/{customerId}/appointments once backend is wired.
-        return await _mock.GetAppointmentsForCustomerAsync(customerId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"customers/{customerId}/appointments", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var appointments = await response.Content.ReadFromJsonAsync<List<AppointmentSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<AppointmentSummary>();
+            foreach (var appointment in appointments)
+            {
+                await _cache.SetAsync(appointment.Id.ToString(), appointment, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return appointments;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<AppointmentSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Where(appointment => appointment.Customer.Id == customerId).ToList();
+        }
     }
 
     public async Task<IReadOnlyList<AppointmentSummary>> GetAppointmentsForVehicleAsync(Guid vehicleId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/vehicles/{vehicleId}/appointments once backend is wired.
-        return await _mock.GetAppointmentsForVehicleAsync(vehicleId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"vehicles/{vehicleId}/appointments", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var appointments = await response.Content.ReadFromJsonAsync<List<AppointmentSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<AppointmentSummary>();
+            foreach (var appointment in appointments)
+            {
+                await _cache.SetAsync(appointment.Id.ToString(), appointment, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return appointments;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<AppointmentSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Where(appointment => appointment.Vehicle.Id == vehicleId).ToList();
+        }
     }
 
     public async Task<IReadOnlyList<AppointmentSummary>> GetUpcomingAppointmentsAsync(int count, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/appointments/upcoming once backend is wired.
-        return await _mock.GetUpcomingAppointmentsAsync(count, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"appointments/upcoming?count={count}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var appointments = await response.Content.ReadFromJsonAsync<List<AppointmentSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<AppointmentSummary>();
+            foreach (var appointment in appointments)
+            {
+                await _cache.SetAsync(appointment.Id.ToString(), appointment, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return appointments;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<AppointmentSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Where(appointment => appointment.ScheduledStart >= DateTime.UtcNow)
+                .OrderBy(appointment => appointment.ScheduledStart)
+                .Take(count)
+                .ToList();
+        }
     }
 
     public async Task<IReadOnlyList<string>> GetStatusesAsync(CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/appointments/statuses once backend is wired.
-        return await _mock.GetStatusesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync("appointments/statuses", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var statuses = await response.Content.ReadFromJsonAsync<List<string>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<string>();
+            _syncState.SetOffline(false);
+            return statuses;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<AppointmentSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Select(appointment => appointment.Status).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(status => status).ToList();
+        }
+    }
+
+    public async Task<AppointmentDetail> SaveAppointmentAsync(AppointmentDetail appointment, CancellationToken cancellationToken = default)
+    {
+        if (appointment is null)
+        {
+            throw new ArgumentNullException(nameof(appointment));
+        }
+
+        var target = appointment.Id == Guid.Empty ? appointment with { Id = Guid.NewGuid() } : appointment;
+        var isNew = appointment.Id == Guid.Empty;
+
+        try
+        {
+            var route = isNew ? "appointments" : $"appointments/{target.Id}";
+            var method = isNew ? HttpMethod.Post : HttpMethod.Put;
+            using var request = new HttpRequestMessage(method, route)
+            {
+                Content = JsonContent.Create(target)
+            };
+
+            var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var saved = await response.Content.ReadFromJsonAsync<AppointmentDetail>(cancellationToken: cancellationToken).ConfigureAwait(false) ?? target;
+            await CacheAppointmentAsync(saved, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(false);
+            return saved;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Queueing appointment {Operation} for {AppointmentId} due to API failure.", isNew ? "create" : "update", target.Id);
+            var envelope = isNew
+                ? ChangeEnvelope.ForCreate("Appointments", target.Id.ToString(), target)
+                : ChangeEnvelope.ForUpdate("Appointments", target.Id.ToString(), target);
+            await _syncQueue.EnqueueChangeAsync(envelope, cancellationToken).ConfigureAwait(false);
+            await CacheAppointmentAsync(target, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(true);
+            return target;
+        }
+    }
+
+    private static string BuildRangeQuery(DateTime? start, DateTime? end, string? status)
+    {
+        var parameters = new List<string>();
+        if (start.HasValue)
+        {
+            parameters.Add($"start={Uri.EscapeDataString(start.Value.ToString("o"))}");
+        }
+
+        if (end.HasValue)
+        {
+            parameters.Add($"end={Uri.EscapeDataString(end.Value.ToString("o"))}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            parameters.Add($"status={Uri.EscapeDataString(status)}");
+        }
+
+        return parameters.Count == 0 ? string.Empty : "?" + string.Join("&", parameters);
+    }
+
+    private IReadOnlyList<AppointmentSummary> FilterAppointments(IReadOnlyList<AppointmentSummary> appointments, DateTime? start, DateTime? end, string? status)
+    {
+        IEnumerable<AppointmentSummary> query = appointments;
+        if (start.HasValue)
+        {
+            query = query.Where(appointment => appointment.ScheduledStart >= start.Value);
+        }
+
+        if (end.HasValue)
+        {
+            query = query.Where(appointment => appointment.ScheduledEnd <= end.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            query = query.Where(appointment => string.Equals(appointment.Status, status, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.OrderBy(appointment => appointment.ScheduledStart).ToList();
+    }
+
+    private async Task CacheAppointmentAsync(AppointmentDetail detail, CancellationToken cancellationToken)
+    {
+        await _cache.SetAsync(detail.Id.ToString(), detail, cancellationToken).ConfigureAwait(false);
+        var summary = BuildSummary(detail);
+        await _cache.SetAsync(summary.Id.ToString(), summary, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static AppointmentSummary BuildSummary(AppointmentDetail detail)
+    {
+        var notesPreview = string.IsNullOrWhiteSpace(detail.Notes)
+            ? null
+            : detail.Notes.Length > 120
+                ? detail.Notes[..120] + "…"
+                : detail.Notes;
+
+        return new AppointmentSummary(
+            detail.Id,
+            detail.AppointmentNumber,
+            detail.ScheduledStart,
+            detail.ScheduledEnd,
+            detail.Status,
+            detail.Service,
+            detail.Technician,
+            detail.Customer,
+            detail.Vehicle,
+            notesPreview);
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Api/Customers/CustomerApiClient.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Api/Customers/CustomerApiClient.cs
@@ -1,35 +1,146 @@
 // CustomerApiClient.cs: HTTP client for customer endpoints, currently delegating to mock data until live routes are ready.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
 using CRMAdapter.UI.Services.Api;
 using CRMAdapter.UI.Services.Contracts;
 using CRMAdapter.UI.Services.Customers.Models;
 using CRMAdapter.UI.Services.Mock.Customers;
+using Microsoft.Extensions.Logging;
 
 namespace CRMAdapter.UI.Services.Api.Customers;
 
 public sealed class CustomerApiClient : BaseApiClient, ICustomerService
 {
     private readonly InMemoryCustomerDirectory _mock;
+    private readonly ILocalCache _cache;
+    private readonly ISyncQueue _syncQueue;
+    private readonly OfflineSyncState _syncState;
+    private readonly ILogger<CustomerApiClient> _logger;
 
-    public CustomerApiClient(HttpClient client, InMemoryCustomerDirectory mock)
+    public CustomerApiClient(
+        HttpClient client,
+        InMemoryCustomerDirectory mock,
+        ILocalCache cache,
+        ISyncQueue syncQueue,
+        OfflineSyncState syncState,
+        ILogger<CustomerApiClient> logger)
         : base(client)
     {
         _mock = mock;
+        _cache = cache;
+        _syncQueue = syncQueue;
+        _syncState = syncState;
+        _logger = logger;
     }
 
     public async Task<IReadOnlyList<CustomerSummary>> GetCustomersAsync(CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/customers once backend is wired.
-        return await _mock.GetCustomersAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync("customers", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var customers = await response.Content.ReadFromJsonAsync<List<CustomerSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<CustomerSummary>();
+            await CacheSummariesAsync(customers, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(false);
+            return customers;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached customers due to API failure.");
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAllAsync<CustomerSummary>(cancellationToken).ConfigureAwait(false);
+            if (cached.Count > 0)
+            {
+                return cached;
+            }
+
+            var mock = await _mock.GetCustomersAsync(cancellationToken).ConfigureAwait(false);
+            await CacheSummariesAsync(mock.ToList(), cancellationToken).ConfigureAwait(false);
+            return mock;
+        }
     }
 
     public async Task<CustomerDetail?> GetCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/customers/{customerId} once backend is wired.
-        return await _mock.GetCustomerAsync(customerId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"customers/{customerId}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var detail = await response.Content.ReadFromJsonAsync<CustomerDetail>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (detail is not null)
+            {
+                await CacheCustomerAsync(detail, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return detail;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached customer {CustomerId} due to API failure.", customerId);
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAsync<CustomerDetail>(customerId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                return cached;
+            }
+
+            return await _mock.GetCustomerAsync(customerId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<CustomerDetail> SaveCustomerAsync(CustomerDetail customer, CancellationToken cancellationToken = default)
+    {
+        if (customer is null)
+        {
+            throw new ArgumentNullException(nameof(customer));
+        }
+
+        try
+        {
+            var response = await Client.PutAsJsonAsync($"customers/{customer.Id}", customer, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var updated = await response.Content.ReadFromJsonAsync<CustomerDetail>(cancellationToken: cancellationToken).ConfigureAwait(false) ?? customer;
+            await CacheCustomerAsync(updated, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(false);
+            return updated;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Queueing customer update for {CustomerId} due to API failure.", customer.Id);
+            await _syncQueue.EnqueueChangeAsync(ChangeEnvelope.ForUpdate("Customers", customer.Id.ToString(), customer), cancellationToken).ConfigureAwait(false);
+            await CacheCustomerAsync(customer, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(true);
+            return customer;
+        }
+    }
+
+    private async Task CacheSummariesAsync(IReadOnlyList<CustomerSummary> customers, CancellationToken cancellationToken)
+    {
+        foreach (var customer in customers)
+        {
+            await _cache.SetAsync(customer.Id.ToString(), customer, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task CacheCustomerAsync(CustomerDetail detail, CancellationToken cancellationToken)
+    {
+        await _cache.SetAsync(detail.Id.ToString(), detail, cancellationToken).ConfigureAwait(false);
+        var summary = new CustomerSummary(
+            detail.Id,
+            detail.Name,
+            detail.Phone,
+            detail.Email,
+            detail.Vehicles.Count,
+            detail.Invoices.OrderByDescending(invoice => invoice.IssuedOn).FirstOrDefault()?.IssuedOn);
+        await _cache.SetAsync(summary.Id.ToString(), summary, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Api/Invoices/InvoiceApiClient.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Api/Invoices/InvoiceApiClient.cs
@@ -1,53 +1,210 @@
 // InvoiceApiClient.cs: HTTP client for invoice workflows, temporarily delegating to the mock workspace.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
 using CRMAdapter.UI.Services.Api;
 using CRMAdapter.UI.Services.Contracts;
 using CRMAdapter.UI.Services.Invoices.Models;
 using CRMAdapter.UI.Services.Mock.Invoices;
+using Microsoft.Extensions.Logging;
 
 namespace CRMAdapter.UI.Services.Api.Invoices;
 
 public sealed class InvoiceApiClient : BaseApiClient, IInvoiceService
 {
     private readonly InMemoryInvoiceWorkspace _mock;
+    private readonly ILocalCache _cache;
+    private readonly ISyncQueue _syncQueue;
+    private readonly OfflineSyncState _syncState;
+    private readonly ILogger<InvoiceApiClient> _logger;
 
-    public InvoiceApiClient(HttpClient client, InMemoryInvoiceWorkspace mock)
+    public InvoiceApiClient(
+        HttpClient client,
+        InMemoryInvoiceWorkspace mock,
+        ILocalCache cache,
+        ISyncQueue syncQueue,
+        OfflineSyncState syncState,
+        ILogger<InvoiceApiClient> logger)
         : base(client)
     {
         _mock = mock;
+        _cache = cache;
+        _syncQueue = syncQueue;
+        _syncState = syncState;
+        _logger = logger;
     }
 
     public async Task<IReadOnlyList<InvoiceSummary>> GetInvoicesAsync(string? search = null, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/invoices?search=... once backend is wired.
-        return await _mock.GetInvoicesAsync(search, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var query = string.IsNullOrWhiteSpace(search) ? string.Empty : $"?search={Uri.EscapeDataString(search)}";
+            var response = await Client.GetAsync($"invoices{query}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var invoices = await response.Content.ReadFromJsonAsync<List<InvoiceSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<InvoiceSummary>();
+            foreach (var invoice in invoices)
+            {
+                await _cache.SetAsync(invoice.Id.ToString(), invoice, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return invoices;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached invoices due to API failure.");
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAllAsync<InvoiceSummary>(cancellationToken).ConfigureAwait(false);
+            return FilterInvoices(cached, search);
+        }
     }
 
     public async Task<InvoiceDetail?> GetInvoiceAsync(Guid invoiceId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/invoices/{invoiceId} once backend is wired.
-        return await _mock.GetInvoiceAsync(invoiceId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"invoices/{invoiceId}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var detail = await response.Content.ReadFromJsonAsync<InvoiceDetail>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (detail is not null)
+            {
+                await CacheInvoiceAsync(detail, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return detail;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached invoice {InvoiceId} due to API failure.", invoiceId);
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAsync<InvoiceDetail>(invoiceId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                return cached;
+            }
+
+            return await _mock.GetInvoiceAsync(invoiceId, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task<IReadOnlyList<InvoiceSummary>> GetInvoicesForCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/customers/{customerId}/invoices once backend is wired.
-        return await _mock.GetInvoicesForCustomerAsync(customerId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"customers/{customerId}/invoices", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var invoices = await response.Content.ReadFromJsonAsync<List<InvoiceSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<InvoiceSummary>();
+            foreach (var invoice in invoices)
+            {
+                await _cache.SetAsync(invoice.Id.ToString(), invoice, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return invoices;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<InvoiceSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Where(invoice => invoice.CustomerId == customerId).ToList();
+        }
     }
 
     public async Task<IReadOnlyList<InvoiceSummary>> GetInvoicesForVehicleAsync(Guid vehicleId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/vehicles/{vehicleId}/invoices once backend is wired.
-        return await _mock.GetInvoicesForVehicleAsync(vehicleId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"vehicles/{vehicleId}/invoices", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var invoices = await response.Content.ReadFromJsonAsync<List<InvoiceSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<InvoiceSummary>();
+            foreach (var invoice in invoices)
+            {
+                await _cache.SetAsync(invoice.Id.ToString(), invoice, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return invoices;
+        }
+        catch (HttpRequestException)
+        {
+            var cached = await _cache.GetAllAsync<InvoiceSummary>(cancellationToken).ConfigureAwait(false);
+            return cached.Where(invoice => invoice.VehicleId == vehicleId).ToList();
+        }
     }
 
     public async Task<InvoiceDetail?> RecordPaymentAsync(Guid invoiceId, PaymentEntry payment, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with POST /api/invoices/{invoiceId}/payments once backend is wired.
-        return await _mock.RecordPaymentAsync(invoiceId, payment, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.PostAsJsonAsync($"invoices/{invoiceId}/payments", payment, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var detail = await response.Content.ReadFromJsonAsync<InvoiceDetail>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (detail is not null)
+            {
+                await CacheInvoiceAsync(detail, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return detail;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Queueing payment for invoice {InvoiceId} due to API failure.", invoiceId);
+            await _syncQueue.EnqueueChangeAsync(ChangeEnvelope.ForUpdate("Invoices", invoiceId.ToString(), new { Payment = payment }), cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAsync<InvoiceDetail>(invoiceId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                var updated = cached with
+                {
+                    PaymentsApplied = cached.PaymentsApplied + payment.Amount,
+                    BalanceDue = Math.Max(0, cached.BalanceDue - payment.Amount)
+                };
+                await CacheInvoiceAsync(updated, cancellationToken).ConfigureAwait(false);
+                return updated;
+            }
+
+            return await _mock.RecordPaymentAsync(invoiceId, payment, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private IReadOnlyList<InvoiceSummary> FilterInvoices(IReadOnlyList<InvoiceSummary> invoices, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return invoices;
+        }
+
+        return invoices
+            .Where(invoice => invoice.InvoiceNumber.Contains(search, StringComparison.OrdinalIgnoreCase)
+                || invoice.CustomerName.Contains(search, StringComparison.OrdinalIgnoreCase)
+                || invoice.VehicleVin.Contains(search, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private async Task CacheInvoiceAsync(InvoiceDetail detail, CancellationToken cancellationToken)
+    {
+        await _cache.SetAsync(detail.Id.ToString(), detail, cancellationToken).ConfigureAwait(false);
+        var summary = new InvoiceSummary(
+            detail.Id,
+            detail.InvoiceNumber,
+            detail.Customer.Id,
+            detail.Customer.Name,
+            detail.Vehicle.Id,
+            detail.Vehicle.Vin,
+            detail.IssuedOn,
+            detail.Status,
+            detail.Total,
+            detail.BalanceDue);
+        await _cache.SetAsync(summary.Id.ToString(), summary, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Api/Vehicles/VehicleApiClient.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Api/Vehicles/VehicleApiClient.cs
@@ -1,35 +1,151 @@
 // VehicleApiClient.cs: HTTP client facade for vehicles, temporarily routing through the mock registry.
 using System;
 using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
 using CRMAdapter.UI.Services.Api;
 using CRMAdapter.UI.Services.Contracts;
 using CRMAdapter.UI.Services.Mock.Vehicles;
 using CRMAdapter.UI.Services.Vehicles.Models;
+using Microsoft.Extensions.Logging;
 
 namespace CRMAdapter.UI.Services.Api.Vehicles;
 
 public sealed class VehicleApiClient : BaseApiClient, IVehicleService
 {
     private readonly InMemoryVehicleRegistry _mock;
+    private readonly ILocalCache _cache;
+    private readonly ISyncQueue _syncQueue;
+    private readonly OfflineSyncState _syncState;
+    private readonly ILogger<VehicleApiClient> _logger;
 
-    public VehicleApiClient(HttpClient client, InMemoryVehicleRegistry mock)
+    public VehicleApiClient(
+        HttpClient client,
+        InMemoryVehicleRegistry mock,
+        ILocalCache cache,
+        ISyncQueue syncQueue,
+        OfflineSyncState syncState,
+        ILogger<VehicleApiClient> logger)
         : base(client)
     {
         _mock = mock;
+        _cache = cache;
+        _syncQueue = syncQueue;
+        _syncState = syncState;
+        _logger = logger;
     }
 
     public async Task<IReadOnlyList<VehicleSummary>> GetVehiclesAsync(CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/vehicles once backend is wired.
-        return await _mock.GetVehiclesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync("vehicles", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var vehicles = await response.Content.ReadFromJsonAsync<List<VehicleSummary>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? new List<VehicleSummary>();
+            foreach (var vehicle in vehicles)
+            {
+                await _cache.SetAsync(vehicle.Id.ToString(), vehicle, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return vehicles;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached vehicles due to API failure.");
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAllAsync<VehicleSummary>(cancellationToken).ConfigureAwait(false);
+            if (cached.Count > 0)
+            {
+                return cached;
+            }
+
+            var mock = await _mock.GetVehiclesAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var vehicle in mock)
+            {
+                await _cache.SetAsync(vehicle.Id.ToString(), vehicle, cancellationToken).ConfigureAwait(false);
+            }
+
+            return mock;
+        }
     }
 
     public async Task<VehicleDetail?> GetVehicleAsync(Guid vehicleId, CancellationToken cancellationToken = default)
     {
-        // TODO: Replace with GET /api/vehicles/{vehicleId} once backend is wired.
-        return await _mock.GetVehicleAsync(vehicleId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await Client.GetAsync($"vehicles/{vehicleId}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var detail = await response.Content.ReadFromJsonAsync<VehicleDetail>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (detail is not null)
+            {
+                await CacheVehicleAsync(detail, cancellationToken).ConfigureAwait(false);
+            }
+
+            _syncState.SetOffline(false);
+            return detail;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Falling back to cached vehicle {VehicleId} due to API failure.", vehicleId);
+            _syncState.SetOffline(true);
+            var cached = await _cache.GetAsync<VehicleDetail>(vehicleId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                return cached;
+            }
+
+            return await _mock.GetVehicleAsync(vehicleId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<VehicleDetail> SaveVehicleAsync(VehicleDetail vehicle, CancellationToken cancellationToken = default)
+    {
+        if (vehicle is null)
+        {
+            throw new ArgumentNullException(nameof(vehicle));
+        }
+
+        try
+        {
+            var response = await Client.PutAsJsonAsync($"vehicles/{vehicle.Id}", vehicle, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var updated = await response.Content.ReadFromJsonAsync<VehicleDetail>(cancellationToken: cancellationToken).ConfigureAwait(false) ?? vehicle;
+            await CacheVehicleAsync(updated, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(false);
+            return updated;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Queueing vehicle update for {VehicleId} due to API failure.", vehicle.Id);
+            await _syncQueue.EnqueueChangeAsync(ChangeEnvelope.ForUpdate("Vehicles", vehicle.Id.ToString(), vehicle), cancellationToken).ConfigureAwait(false);
+            await CacheVehicleAsync(vehicle, cancellationToken).ConfigureAwait(false);
+            _syncState.SetOffline(true);
+            return vehicle;
+        }
+    }
+
+    private async Task CacheVehicleAsync(VehicleDetail detail, CancellationToken cancellationToken)
+    {
+        await _cache.SetAsync(detail.Id.ToString(), detail, cancellationToken).ConfigureAwait(false);
+        var summary = new VehicleSummary(
+            detail.Id,
+            detail.Vin,
+            detail.Year,
+            detail.Make,
+            detail.Model,
+            detail.Owner.Id,
+            detail.Owner.Name,
+            detail.Plate,
+            detail.Status,
+            detail.LastServiceDate);
+        await _cache.SetAsync(summary.Id.ToString(), summary, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Contracts/IAppointmentService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Contracts/IAppointmentService.cs
@@ -24,4 +24,6 @@ public interface IAppointmentService
     Task<IReadOnlyList<AppointmentSummary>> GetUpcomingAppointmentsAsync(int count, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<string>> GetStatusesAsync(CancellationToken cancellationToken = default);
+
+    Task<AppointmentDetail> SaveAppointmentAsync(AppointmentDetail appointment, CancellationToken cancellationToken = default);
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Contracts/ICustomerService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Contracts/ICustomerService.cs
@@ -12,4 +12,6 @@ public interface ICustomerService
     Task<IReadOnlyList<CustomerSummary>> GetCustomersAsync(CancellationToken cancellationToken = default);
 
     Task<CustomerDetail?> GetCustomerAsync(Guid customerId, CancellationToken cancellationToken = default);
+
+    Task<CustomerDetail> SaveCustomerAsync(CustomerDetail customer, CancellationToken cancellationToken = default);
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Contracts/IVehicleService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Contracts/IVehicleService.cs
@@ -12,4 +12,6 @@ public interface IVehicleService
     Task<IReadOnlyList<VehicleSummary>> GetVehiclesAsync(CancellationToken cancellationToken = default);
 
     Task<VehicleDetail?> GetVehicleAsync(Guid vehicleId, CancellationToken cancellationToken = default);
+
+    Task<VehicleDetail> SaveVehicleAsync(VehicleDetail vehicle, CancellationToken cancellationToken = default);
 }

--- a/CRMAdapter/CRMAdapter.UI/Services/Mock/Appointments/InMemoryAppointmentBook.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Mock/Appointments/InMemoryAppointmentBook.cs
@@ -103,6 +103,12 @@ public sealed class InMemoryAppointmentBook : IAppointmentService
         return Task.FromResult<IReadOnlyList<string>>(statuses);
     }
 
+    public Task<AppointmentDetail> SaveAppointmentAsync(AppointmentDetail appointment, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(appointment);
+    }
+
     internal static AppointmentSummary CreateSummary(AppointmentSeedRecord record)
     {
         return new AppointmentSummary(

--- a/CRMAdapter/CRMAdapter.UI/Services/Mock/Customers/InMemoryCustomerDirectory.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Mock/Customers/InMemoryCustomerDirectory.cs
@@ -42,6 +42,12 @@ public sealed class InMemoryCustomerDirectory : ICustomerService
         return Task.FromResult(customer);
     }
 
+    public Task<CustomerDetail> SaveCustomerAsync(CustomerDetail customer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(customer);
+    }
+
     private static IReadOnlyList<CustomerDetail> SeedCustomers()
     {
         var appointmentsByCustomer = AppointmentSeedData.Records

--- a/CRMAdapter/CRMAdapter.UI/Services/Mock/Vehicles/InMemoryVehicleRegistry.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Mock/Vehicles/InMemoryVehicleRegistry.cs
@@ -48,6 +48,12 @@ public sealed class InMemoryVehicleRegistry : IVehicleService
         return Task.FromResult(vehicle);
     }
 
+    public Task<VehicleDetail> SaveVehicleAsync(VehicleDetail vehicle, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(vehicle);
+    }
+
     private static IReadOnlyList<VehicleDetail> SeedVehicles()
     {
         var appointmentsByVehicle = AppointmentSeedData.Records

--- a/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/MainLayout.razor
@@ -4,7 +4,9 @@
 @inject AppThemeState ThemeState
 @inject ISnackbar Snackbar
 @inject IWebHostEnvironment HostEnvironment
+@inject CRMAdapter.UI.Core.Sync.ConnectivityMonitor ConnectivityMonitor
 @implements IDisposable
+@implements IAsyncDisposable
 
 <MudLayout Class="crm-layout">
     <MudBreakpointProvider OnBreakpointChanged="OnBreakpointChanged" Breakpoint="Breakpoint.Md" Immediate="true" />
@@ -20,12 +22,14 @@
 
     <MudMainContent>
         <section class="crm-grid" aria-live="polite">
+            <OfflineBanner />
             <header class="crm-topbar">
                 <TopBar OnToggleNavigation="ToggleDrawer" OnThemeToggle="ToggleTheme" OnSearch="HandleSearch" />
                 @if (HostEnvironment.IsDevelopment())
                 {
                     <DataSourceSwitch />
                 }
+                <SyncStatus />
             </header>
             <main id="main-content" class="crm-content" tabindex="-1">
                 <MudPaper Class="crm-content-surface" Elevation="0">
@@ -45,6 +49,14 @@
     protected override void OnInitialized()
     {
         ThemeState.OnChange += OnThemeChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await ConnectivityMonitor.InitializeAsync();
+        }
     }
 
     private void ToggleDrawer() => _isDrawerOpen = !_isDrawerOpen;
@@ -86,5 +98,11 @@
     public void Dispose()
     {
         ThemeState.OnChange -= OnThemeChanged;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Dispose();
+        await ConnectivityMonitor.DisposeAsync();
     }
 }

--- a/CRMAdapter/CRMAdapter.UI/Shared/OfflineBanner.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/OfflineBanner.razor
@@ -1,0 +1,35 @@
+@* OfflineBanner.razor: Displays a prominent banner while the app is offline. *@
+@inject CRMAdapter.UI.Core.Sync.OfflineSyncState SyncState
+@implements IDisposable
+
+@if (_isOffline)
+{
+    <MudAlert Severity="Severity.Warning" Elevation="0" Class="offline-banner" Icon="@Icons.Material.Filled.CloudOff">
+        Offline Mode: Changes will sync automatically when reconnected.
+    </MudAlert>
+}
+
+@code {
+    private bool _isOffline;
+
+    protected override void OnInitialized()
+    {
+        _isOffline = SyncState.IsOffline;
+        SyncState.StateChanged += OnStateChanged;
+    }
+
+    private void OnStateChanged()
+    {
+        var shouldRender = _isOffline != SyncState.IsOffline;
+        _isOffline = SyncState.IsOffline;
+        if (shouldRender)
+        {
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        SyncState.StateChanged -= OnStateChanged;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Shared/SyncStatus.razor
+++ b/CRMAdapter/CRMAdapter.UI/Shared/SyncStatus.razor
@@ -1,0 +1,92 @@
+@* SyncStatus.razor: Presents queue length, last sync timestamp, and activity indicator. *@
+@inject CRMAdapter.UI.Core.Sync.OfflineSyncState SyncState
+@inject ISnackbar Snackbar
+@implements IDisposable
+
+<div class="sync-status" aria-live="polite">
+    <MudIconButton Icon="@GetIcon()" Color="Color.Inherit" Disabled="true" Class="sync-status__icon" />
+    <div class="sync-status__details">
+        <div class="sync-status__headline">@GetHeadline()</div>
+        <div class="sync-status__meta">@GetSubText()</div>
+    </div>
+</div>
+
+@code {
+    private bool _isSyncing;
+    private int _queueLength;
+    private DateTimeOffset? _lastSync;
+
+    protected override void OnInitialized()
+    {
+        _isSyncing = SyncState.IsSyncing;
+        _queueLength = SyncState.QueueLength;
+        _lastSync = SyncState.LastSuccessfulSync;
+        SyncState.StateChanged += OnStateChanged;
+        SyncState.ConflictDetected += OnConflict;
+    }
+
+    private void OnStateChanged()
+    {
+        _isSyncing = SyncState.IsSyncing;
+        _queueLength = SyncState.QueueLength;
+        _lastSync = SyncState.LastSuccessfulSync;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnConflict(CRMAdapter.UI.Core.Sync.SyncConflictNotification notification)
+    {
+        Snackbar.Add($"Conflict detected for {notification.EntityType} {notification.EntityId}. Server version kept.", Severity.Warning);
+        InvokeAsync(StateHasChanged);
+    }
+
+    private string GetHeadline()
+    {
+        if (_isSyncing)
+        {
+            return "Syncing changes…";
+        }
+
+        if (_queueLength > 0)
+        {
+            return $"{_queueLength} change(s) pending";
+        }
+
+        return "All changes synced";
+    }
+
+    private string GetSubText()
+    {
+        if (_queueLength == 0 && _lastSync.HasValue)
+        {
+            return $"Last sync: {_lastSync.Value.ToLocalTime():g}";
+        }
+
+        if (_queueLength > 0)
+        {
+            return "Waiting for connectivity";
+        }
+
+        return "No pending work";
+    }
+
+    private string GetIcon()
+    {
+        if (_isSyncing)
+        {
+            return Icons.Material.Filled.Autorenew;
+        }
+
+        if (_queueLength > 0)
+        {
+            return Icons.Material.Filled.CloudOff;
+        }
+
+        return Icons.Material.Filled.CloudDone;
+    }
+
+    public void Dispose()
+    {
+        SyncState.StateChanged -= OnStateChanged;
+        SyncState.ConflictDetected -= OnConflict;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/appsettings.json
+++ b/CRMAdapter/CRMAdapter.UI/appsettings.json
@@ -15,5 +15,9 @@
   "Api": {
     "BaseUrl": "https://localhost:5001"
   },
+  "OfflineSync": {
+    "Enabled": true,
+    "IntervalSeconds": 20
+  },
   "AllowedHosts": "*"
 }

--- a/CRMAdapter/CRMAdapter.UI/wwwroot/app.css
+++ b/CRMAdapter/CRMAdapter.UI/wwwroot/app.css
@@ -57,3 +57,56 @@ body.mud-theme-dark .landing-hero {
 .mud-chip.crm-correlation-chip {
     font-size: 0.75rem;
 }
+
+.offline-banner {
+    margin-bottom: 1rem;
+    border-left: 4px solid #ef4444;
+    background-color: rgba(239, 68, 68, 0.1);
+}
+
+.sync-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.7);
+    color: inherit;
+}
+
+body.mud-theme-dark .sync-status {
+    background-color: rgba(15, 23, 42, 0.6);
+}
+
+.sync-status__icon {
+    animation: sync-spin 1.2s linear infinite;
+}
+
+.sync-status__details {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.1;
+}
+
+.sync-status__headline {
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.sync-status__meta {
+    font-size: 0.75rem;
+    opacity: 0.8;
+}
+
+@keyframes sync-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.sync-status .mud-icon-button[disabled] {
+    opacity: 1;
+}

--- a/CRMAdapter/CRMAdapter.UI/wwwroot/js/offlineCache.js
+++ b/CRMAdapter/CRMAdapter.UI/wwwroot/js/offlineCache.js
@@ -1,0 +1,102 @@
+const dbName = 'crmAdapterOffline';
+const storeName = 'entries';
+let dbPromise = null;
+let connectivityHandlers = null;
+
+function openDb() {
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(dbName, 1);
+            request.onupgradeneeded = () => {
+                const db = request.result;
+                if (!db.objectStoreNames.contains(storeName)) {
+                    db.createObjectStore(storeName, { keyPath: 'id' });
+                }
+            };
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => resolve(request.result);
+        });
+    }
+
+    return dbPromise;
+}
+
+async function withStore(mode) {
+    const db = await openDb();
+    const transaction = db.transaction(storeName, mode);
+    return transaction.objectStore(storeName);
+}
+
+function compositeKey(typeKey, key) {
+    return `${typeKey}::${key}`;
+}
+
+export async function setEntry(typeKey, key, jsonPayload) {
+    const store = await withStore('readwrite');
+    return new Promise((resolve, reject) => {
+        const request = store.put({ id: compositeKey(typeKey, key), typeKey, json: jsonPayload });
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function getEntry(typeKey, key) {
+    const store = await withStore('readonly');
+    return new Promise((resolve, reject) => {
+        const request = store.get(compositeKey(typeKey, key));
+        request.onsuccess = () => resolve(request.result ? request.result.json : null);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function deleteEntry(typeKey, key) {
+    const store = await withStore('readwrite');
+    return new Promise((resolve, reject) => {
+        const request = store.delete(compositeKey(typeKey, key));
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function getAllEntries(typeKey) {
+    const store = await withStore('readonly');
+    return new Promise((resolve, reject) => {
+        const items = [];
+        const request = store.openCursor();
+        request.onsuccess = event => {
+            const cursor = event.target.result;
+            if (cursor) {
+                if (cursor.value.typeKey === typeKey) {
+                    items.push(cursor.value.json);
+                }
+                cursor.continue();
+            } else {
+                resolve(items);
+            }
+        };
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function registerConnectivity(dotnetRef) {
+    if (!dotnetRef) {
+        return;
+    }
+
+    const notify = () => dotnetRef.invokeMethodAsync('UpdateOnlineStatus', navigator.onLine);
+    notify();
+
+    const onlineHandler = () => notify();
+    const offlineHandler = () => notify();
+    window.addEventListener('online', onlineHandler);
+    window.addEventListener('offline', offlineHandler);
+    connectivityHandlers = { onlineHandler, offlineHandler };
+}
+
+export async function disposeConnectivity() {
+    if (connectivityHandlers) {
+        window.removeEventListener('online', connectivityHandlers.onlineHandler);
+        window.removeEventListener('offline', connectivityHandlers.offlineHandler);
+        connectivityHandlers = null;
+    }
+}

--- a/CRMAdapter/Tests/CRMAdapter.UI.Tests/Offline/OfflineCacheTests.cs
+++ b/CRMAdapter/Tests/CRMAdapter.UI.Tests/Offline/OfflineCacheTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
+using CRMAdapter.UI.Services.Api.Customers;
+using CRMAdapter.UI.Services.Customers.Models;
+using CRMAdapter.UI.Services.Mock.Customers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CRMAdapter.UI.Tests.Offline;
+
+public sealed class OfflineCacheTests : IDisposable
+{
+    private readonly List<string> _paths = new();
+
+    [Fact]
+    public async Task Reads_from_cache_when_api_down()
+    {
+        var cache = CreateCache();
+        var state = new OfflineSyncState();
+        var handler = new StubHandler(JsonSerializer.Serialize(new List<CustomerSummary>
+        {
+            new(Guid.NewGuid(), "Test Customer", "+1-555-0100", "test@example.com", 2, DateTime.UtcNow)
+        }));
+        var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://localhost")
+        };
+        var service = new CustomerApiClient(
+            client,
+            new InMemoryCustomerDirectory(),
+            cache,
+            new NoopSyncQueue(),
+            state,
+            NullLogger<CustomerApiClient>.Instance);
+
+        var initial = await service.GetCustomersAsync();
+        initial.Should().ContainSingle().Which.Name.Should().Be("Test Customer");
+
+        var offlineClient = new CustomerApiClient(
+            new HttpClient(new ThrowingHandler()) { BaseAddress = new Uri("https://localhost") },
+            new InMemoryCustomerDirectory(),
+            cache,
+            new NoopSyncQueue(),
+            state,
+            NullLogger<CustomerApiClient>.Instance);
+
+        var offline = await offlineClient.GetCustomersAsync();
+        offline.Should().ContainSingle().Which.Name.Should().Be("Test Customer");
+    }
+
+    [Fact]
+    public async Task Enqueued_changes_replay_when_api_restored()
+    {
+        var cache = CreateCache();
+        var state = new OfflineSyncState();
+        var queue = new SyncQueue(cache, state, NullLogger<SyncQueue>.Instance);
+        var dispatcher = new ToggleDispatcher();
+        var worker = new BackgroundSyncWorker(
+            queue,
+            dispatcher,
+            state,
+            cache,
+            Options.Create(new OfflineSyncOptions { Enabled = true, IntervalSeconds = 1 }),
+            NullLogger<BackgroundSyncWorker>.Instance);
+
+        await queue.EnqueueChangeAsync(ChangeEnvelope.ForUpdate("Customers", Guid.NewGuid().ToString(), new { Name = "Offline" }));
+
+        dispatcher.ShouldFail = true;
+        await worker.FlushAsync(CancellationToken.None);
+        (await queue.GetLengthAsync()).Should().Be(1);
+
+        dispatcher.ShouldFail = false;
+        await worker.FlushAsync(CancellationToken.None);
+        (await queue.GetLengthAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Server_wins_on_conflict()
+    {
+        var cache = CreateCache();
+        var state = new OfflineSyncState();
+        var queue = new SyncQueue(cache, state, NullLogger<SyncQueue>.Instance);
+        var dispatcher = new ConflictDispatcher();
+        var worker = new BackgroundSyncWorker(
+            queue,
+            dispatcher,
+            state,
+            cache,
+            Options.Create(new OfflineSyncOptions { Enabled = true, IntervalSeconds = 1 }),
+            NullLogger<BackgroundSyncWorker>.Instance);
+
+        var customerId = Guid.NewGuid();
+        await queue.EnqueueChangeAsync(ChangeEnvelope.ForUpdate("Customers", customerId.ToString(), new { Name = "Local" }));
+
+        var conflictRaised = false;
+        state.ConflictDetected += _ => conflictRaised = true;
+
+        dispatcher.Payload = JsonSerializer.Serialize(new CustomerDetail(
+            customerId,
+            "Server Customer",
+            "server@example.com",
+            "+1-555-4242",
+            "Notes",
+            Array.Empty<VehicleRecord>(),
+            Array.Empty<InvoiceRecord>(),
+            Array.Empty<AppointmentRecord>()));
+
+        await worker.FlushAsync(CancellationToken.None);
+
+        conflictRaised.Should().BeTrue();
+        (await queue.GetLengthAsync()).Should().Be(0);
+        var cachedCustomer = await cache.GetAsync<CustomerDetail>(customerId.ToString());
+        cachedCustomer.Should().NotBeNull();
+        cachedCustomer!.Name.Should().Be("Server Customer");
+    }
+
+    private ILocalCache CreateCache()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "crm-offline-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        _paths.Add(path);
+        return new FileSystemCache(path);
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in _paths)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    private sealed class NoopSyncQueue : ISyncQueue
+    {
+        public Task EnqueueChangeAsync(ChangeEnvelope change, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<ChangeEnvelope>> DequeueAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ChangeEnvelope>>(Array.Empty<ChangeEnvelope>());
+
+        public Task MarkSyncedAsync(Guid correlationId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<int> GetLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _payload;
+
+        public StubHandler(string payload)
+        {
+            _payload = payload;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_payload, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("Offline");
+    }
+
+    private sealed class ToggleDispatcher : IChangeDispatcher
+    {
+        public bool ShouldFail { get; set; }
+
+        public Task<ChangeDispatchResult> DispatchAsync(ChangeEnvelope change, CancellationToken cancellationToken)
+        {
+            if (ShouldFail)
+            {
+                return Task.FromResult(ChangeDispatchResult.Failed("offline"));
+            }
+
+            return Task.FromResult(ChangeDispatchResult.Successful(DateTimeOffset.UtcNow));
+        }
+    }
+
+    private sealed class ConflictDispatcher : IChangeDispatcher
+    {
+        public string Payload { get; set; } = string.Empty;
+
+        public Task<ChangeDispatchResult> DispatchAsync(ChangeEnvelope change, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ChangeDispatchResult.ConflictDetected(DateTimeOffset.UtcNow, Payload, "Conflict"));
+        }
+    }
+}

--- a/CRMAdapter/Tests/CRMAdapter.UI.Tests/Offline/SyncQueueTests.cs
+++ b/CRMAdapter/Tests/CRMAdapter.UI.Tests/Offline/SyncQueueTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CRMAdapter.UI.Core.Storage;
+using CRMAdapter.UI.Core.Sync;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CRMAdapter.UI.Tests.Offline;
+
+public sealed class SyncQueueTests : IDisposable
+{
+    private readonly string _path;
+    private readonly ILocalCache _cache;
+    private readonly OfflineSyncState _state = new();
+
+    public SyncQueueTests()
+    {
+        _path = Path.Combine(Path.GetTempPath(), "crm-sync-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_path);
+        _cache = new FileSystemCache(_path);
+    }
+
+    [Fact]
+    public async Task Enqueue_and_mark_synced_lifecycle()
+    {
+        var queue = new SyncQueue(_cache, _state, NullLogger<SyncQueue>.Instance);
+        var change = ChangeEnvelope.ForUpdate("Customers", Guid.NewGuid().ToString(), new { Name = "Test" });
+
+        await queue.EnqueueChangeAsync(change);
+        (await queue.GetLengthAsync()).Should().Be(1);
+
+        var pending = await queue.DequeueAllAsync();
+        pending.Should().ContainSingle().Which.CorrelationId.Should().Be(change.CorrelationId);
+
+        await queue.MarkSyncedAsync(change.CorrelationId);
+        (await queue.GetLengthAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Dequeue_orders_by_timestamp()
+    {
+        var queue = new SyncQueue(_cache, _state, NullLogger<SyncQueue>.Instance);
+        var changeA = new ChangeEnvelope("Invoices", "A", ChangeOperation.Update, "{}", DateTimeOffset.UtcNow.AddMinutes(-5), Guid.NewGuid());
+        var changeB = new ChangeEnvelope("Invoices", "B", ChangeOperation.Update, "{}", DateTimeOffset.UtcNow, Guid.NewGuid());
+
+        await queue.EnqueueChangeAsync(changeB);
+        await queue.EnqueueChangeAsync(changeA);
+
+        var pending = await queue.DequeueAllAsync();
+        pending.Should().HaveCount(2);
+        pending[0].EntityId.Should().Be("A");
+        pending[1].EntityId.Should().Be("B");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_path))
+            {
+                Directory.Delete(_path, true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ILocalCache abstractions for IndexedDB and filesystem storage along with sync queue infrastructure and background worker
- retrofit CRM services to hydrate from cache, queue failed mutations, and update offline state for UI feedback
- surface offline banner/sync status, wire connectivity monitoring, document workflow, and cover queue/offline scenarios with tests

## Testing
- `dotnet test ../CRMAdapter.sln --filter CRMAdapter.UI.Tests` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d44da361f8832f9ac9e24e29761c6e