### PR TITLE
Implement centralized audit logging

### DIFF
--- a/CRMAdapter/CRMAdapter.Api/CRMAdapter.Api.csproj
+++ b/CRMAdapter/CRMAdapter.Api/CRMAdapter.Api.csproj
@@ -37,6 +37,10 @@
       <Link>Config\RbacMatrix.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\CommonConfig\AuditSettings.json">
+      <Link>Config\AuditSettings.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Docs\openapi.xml" />
     <Content Include="..\Vast\Mapping\vast-desktop.json">
       <Link>Mappings\vast-desktop.json</Link>

--- a/CRMAdapter/CRMAdapter.Api/Middleware/AuditMiddleware.cs
+++ b/CRMAdapter/CRMAdapter.Api/Middleware/AuditMiddleware.cs
@@ -1,0 +1,258 @@
+// AuditMiddleware.cs: Captures API activity and emits structured audit events before and after execution.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Middleware;
+
+/// <summary>
+/// Emits centralized audit events for every API invocation, including denied access attempts.
+/// </summary>
+public sealed class AuditMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly AuditLogger _auditLogger;
+    private readonly ILogger<AuditMiddleware> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuditMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware component.</param>
+    /// <param name="auditLogger">Audit logger used to emit structured events.</param>
+    /// <param name="logger">Framework logger used for operational diagnostics.</param>
+    public AuditMiddleware(RequestDelegate next, AuditLogger auditLogger, ILogger<AuditMiddleware> logger)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _auditLogger = auditLogger ?? throw new ArgumentNullException(nameof(auditLogger));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Processes the HTTP request, emitting audit events before and after the action executes.
+    /// </summary>
+    /// <param name="context">Current HTTP request context.</param>
+    /// <returns>A task that completes when the request has been processed.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var cancellationToken = context.RequestAborted;
+        var correlationId = ResolveCorrelationId(context);
+        var userId = ResolveUserId(context.User);
+        var role = ResolveRole(context.User);
+        var action = ResolveAction(context.Request);
+        var entityId = ResolveEntityId(context.GetRouteData());
+
+        await _auditLogger.LogAsync(
+            new AuditEvent(
+                correlationId,
+                userId,
+                role,
+                action + ".Attempt",
+                entityId,
+                DateTimeOffset.UtcNow,
+                AuditResult.Success,
+                new Dictionary<string, string>
+                {
+                    ["origin"] = "API",
+                    ["stage"] = "Attempt",
+                    ["method"] = context.Request.Method,
+                }),
+            cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await _next(context).ConfigureAwait(false);
+            var outcome = ResolveResult(context.Response?.StatusCode ?? StatusCodes.Status500InternalServerError);
+            await _auditLogger.LogAsync(
+                new AuditEvent(
+                    correlationId,
+                    userId,
+                    role,
+                    action,
+                    entityId,
+                    DateTimeOffset.UtcNow,
+                    outcome,
+                    new Dictionary<string, string>
+                    {
+                        ["origin"] = "API",
+                        ["stage"] = "Completion",
+                        ["statusCode"] = (context.Response?.StatusCode ?? 0).ToString(CultureInfo.InvariantCulture),
+                    }),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception while executing {Action} for correlation {CorrelationId}.", action, correlationId);
+            await _auditLogger.LogAsync(
+                new AuditEvent(
+                    correlationId,
+                    userId,
+                    role,
+                    action,
+                    entityId,
+                    DateTimeOffset.UtcNow,
+                    AuditResult.Failure,
+                    new Dictionary<string, string>
+                    {
+                        ["origin"] = "API",
+                        ["stage"] = "Completion",
+                        ["exception"] = ex.GetType().Name,
+                    }),
+                cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static string ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Items.TryGetValue(CorrelationIdMiddleware.CorrelationHeaderName, out var value)
+            && value is string explicitId
+            && !string.IsNullOrWhiteSpace(explicitId))
+        {
+            return explicitId.Trim();
+        }
+
+        return context.TraceIdentifier;
+    }
+
+    private static string ResolveUserId(ClaimsPrincipal principal)
+    {
+        if (principal.Identity?.IsAuthenticated == true)
+        {
+            var claim = principal.FindFirst("sub")
+                ?? principal.FindFirst(ClaimTypes.NameIdentifier)
+                ?? principal.FindFirst("oid")
+                ?? principal.FindFirst("email");
+            if (claim is not null && !string.IsNullOrWhiteSpace(claim.Value))
+            {
+                return claim.Value;
+            }
+        }
+
+        return "anonymous";
+    }
+
+    private static string ResolveRole(ClaimsPrincipal principal)
+    {
+        if (principal.Identity?.IsAuthenticated == true)
+        {
+            var roleClaim = principal.FindAll(ClaimTypes.Role).Select(claim => claim.Value).FirstOrDefault()
+                ?? principal.FindAll("role").Select(claim => claim.Value).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(roleClaim))
+            {
+                return roleClaim;
+            }
+        }
+
+        return "guest";
+    }
+
+    private static string ResolveAction(HttpRequest request)
+    {
+        var segments = request.Path.HasValue
+            ? request.Path.Value!.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries)
+            : Array.Empty<string>();
+
+        var resource = segments.Length > 0 ? segments[0] : "Root";
+        if (resource.EndsWith("s", StringComparison.OrdinalIgnoreCase) && resource.Length > 1)
+        {
+            resource = resource[..^1];
+        }
+
+        resource = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(resource.Replace('-', ' ')).Replace(" ", string.Empty, StringComparison.Ordinal);
+        var operationSegment = segments.Length > 1 ? segments[^1] : string.Empty;
+        if (!string.IsNullOrWhiteSpace(operationSegment)
+            && !operationSegment.Equals(segments[0], StringComparison.OrdinalIgnoreCase)
+            && !Guid.TryParse(operationSegment, out _)
+            && !long.TryParse(operationSegment, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        {
+            var operation = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(operationSegment.Replace('-', ' ')).Replace(" ", string.Empty, StringComparison.Ordinal);
+            return $"{resource}.{operation}";
+        }
+
+        var action = request.Method.ToUpperInvariant() switch
+        {
+            "GET" => "View",
+            "POST" => "Create",
+            "PUT" => "Update",
+            "PATCH" => "Update",
+            "DELETE" => "Delete",
+            _ => request.Method.ToUpperInvariant(),
+        };
+
+        return $"{resource}.{action}";
+    }
+
+    private static string? ResolveEntityId(RouteData? routeData)
+    {
+        if (routeData is null)
+        {
+            return null;
+        }
+
+        foreach (var value in routeData.Values)
+        {
+            if (value.Value is null)
+            {
+                continue;
+            }
+
+            if (value.Key.EndsWith("id", StringComparison.OrdinalIgnoreCase))
+            {
+                var candidate = value.Value.ToString();
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    continue;
+                }
+
+                if (Guid.TryParse(candidate, out var guid))
+                {
+                    return guid.ToString("N", CultureInfo.InvariantCulture);
+                }
+
+                return MaskEntity(candidate);
+            }
+        }
+
+        return null;
+    }
+
+    private static string MaskEntity(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length <= 4)
+        {
+            return new string('*', trimmed.Length);
+        }
+
+        var head = trimmed[..2];
+        var tail = trimmed[^2..];
+        return string.Concat(head, new string('*', trimmed.Length - 4), tail);
+    }
+
+    private static AuditResult ResolveResult(int statusCode)
+    {
+        if (statusCode == StatusCodes.Status401Unauthorized || statusCode == StatusCodes.Status403Forbidden)
+        {
+            return AuditResult.Denied;
+        }
+
+        if (statusCode >= 200 && statusCode < 400)
+        {
+            return AuditResult.Success;
+        }
+
+        return AuditResult.Failure;
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Program.cs
+++ b/CRMAdapter/CRMAdapter.Api/Program.cs
@@ -1,8 +1,11 @@
 // File: Program.cs
 // Summary: Entry point for the CRMAdapter.Api application that wires up the minimal API pipeline.
+using System.IO;
 using CRMAdapter.Api.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddJsonFile(Path.Combine(builder.Environment.ContentRootPath, "Config", "AuditSettings.json"), optional: true, reloadOnChange: true);
 
 SerilogConfig.Configure(builder);
 

--- a/CRMAdapter/CRMAdapter.Api/Startup.cs
+++ b/CRMAdapter/CRMAdapter.Api/Startup.cs
@@ -56,6 +56,7 @@ public sealed class Startup
 
         services.AddOptions();
         services.AddHttpContextAccessor();
+        services.AddAuditLogging(_configuration);
         services.Configure<JwtConfig>(_configuration.GetSection(JwtConfig.SectionName));
 
         var jwtConfig = _configuration.GetSection(JwtConfig.SectionName).Get<JwtConfig>() ?? new JwtConfig();
@@ -132,6 +133,7 @@ public sealed class Startup
         }
 
         app.UseAuthentication();
+        app.UseMiddleware<AuditMiddleware>();
         app.UseAuthorization();
 
         app.UseSwagger();

--- a/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
+++ b/CRMAdapter/CRMAdapter.UI/CRMAdapter.UI.csproj
@@ -20,6 +20,10 @@
       <Link>Config\RbacMatrix.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\CommonConfig\AuditSettings.json">
+      <Link>Config\AuditSettings.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/CRMAdapter/CRMAdapter.UI/Components/Audit/AuditActionInvoker.razor
+++ b/CRMAdapter/CRMAdapter.UI/Components/Audit/AuditActionInvoker.razor
@@ -1,0 +1,168 @@
+@* AuditActionInvoker.razor: Wraps UI actions with centralized audit logging semantics. *@
+@using System.Security.Claims
+@using CRMAdapter.CommonSecurity
+@using CRMAdapter.UI.Services.Diagnostics
+@inject AuditLogger AuditLogger
+@inject CorrelationContext CorrelationContext
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+@if (ChildContent is not null)
+{
+    @ChildContent(_callback)
+}
+
+@code {
+    [Parameter]
+    [EditorRequired]
+    public string Action { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? EntityId { get; set; }
+
+    [Parameter]
+    public EventCallback OnExecute { get; set; }
+
+    [Parameter]
+    public RenderFragment<EventCallback>? ChildContent { get; set; }
+
+    private EventCallback _callback;
+
+    protected override void OnParametersSet()
+    {
+        if (ChildContent is null)
+        {
+            throw new InvalidOperationException("AuditActionInvoker requires child content supplying an executable element.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Action))
+        {
+            throw new InvalidOperationException("AuditActionInvoker requires a non-empty action name.");
+        }
+
+        _callback = EventCallback.Factory.Create(this, InvokeAsync);
+    }
+
+    private async Task InvokeAsync()
+    {
+        var correlationId = CorrelationContext.CurrentCorrelationId;
+        var principal = await ResolvePrincipalAsync().ConfigureAwait(false);
+        var userId = ResolveUserId(principal);
+        var role = ResolveRole(principal);
+        var maskedEntity = MaskEntityId(EntityId);
+
+        await AuditLogger.LogAsync(new AuditEvent(
+            correlationId,
+            userId,
+            role,
+            $"{Action}.Attempt",
+            maskedEntity,
+            DateTimeOffset.UtcNow,
+            AuditResult.Success,
+            new Dictionary<string, string>
+            {
+                ["origin"] = "UI",
+                ["stage"] = "Attempt",
+            })).ConfigureAwait(false);
+
+        try
+        {
+            if (OnExecute.HasDelegate)
+            {
+                await OnExecute.InvokeAsync(null).ConfigureAwait(false);
+            }
+
+            await AuditLogger.LogAsync(new AuditEvent(
+                correlationId,
+                userId,
+                role,
+                Action,
+                maskedEntity,
+                DateTimeOffset.UtcNow,
+                AuditResult.Success,
+                new Dictionary<string, string>
+                {
+                    ["origin"] = "UI",
+                    ["stage"] = "Completion",
+                })).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await AuditLogger.LogAsync(new AuditEvent(
+                correlationId,
+                userId,
+                role,
+                Action,
+                maskedEntity,
+                DateTimeOffset.UtcNow,
+                AuditResult.Failure,
+                new Dictionary<string, string>
+                {
+                    ["origin"] = "UI",
+                    ["stage"] = "Completion",
+                    ["exception"] = ex.GetType().Name,
+                })).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<ClaimsPrincipal> ResolvePrincipalAsync()
+    {
+        var state = await AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(false);
+        return state.User;
+    }
+
+    private static string ResolveUserId(ClaimsPrincipal principal)
+    {
+        if (principal.Identity?.IsAuthenticated == true)
+        {
+            var claim = principal.FindFirst("sub")
+                ?? principal.FindFirst(ClaimTypes.NameIdentifier)
+                ?? principal.FindFirst("oid")
+                ?? principal.FindFirst("email");
+            if (claim is not null && !string.IsNullOrWhiteSpace(claim.Value))
+            {
+                return claim.Value;
+            }
+        }
+
+        return "anonymous";
+    }
+
+    private static string ResolveRole(ClaimsPrincipal principal)
+    {
+        if (principal.Identity?.IsAuthenticated == true)
+        {
+            var roleClaim = principal.FindAll(ClaimTypes.Role).Select(claim => claim.Value).FirstOrDefault()
+                ?? principal.FindAll("role").Select(claim => claim.Value).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(roleClaim))
+            {
+                return roleClaim;
+            }
+        }
+
+        return "guest";
+    }
+
+    private static string? MaskEntityId(string? entityId)
+    {
+        if (string.IsNullOrWhiteSpace(entityId))
+        {
+            return null;
+        }
+
+        var trimmed = entityId.Trim();
+        if (Guid.TryParse(trimmed, out var guid))
+        {
+            return guid.ToString("N");
+        }
+
+        if (trimmed.Length <= 4)
+        {
+            return new string('*', trimmed.Length);
+        }
+
+        var head = trimmed[..2];
+        var tail = trimmed[^2..];
+        return string.Concat(head, new string('*', trimmed.Length - 4), tail);
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/Pages/Invoices/Detail.razor
+++ b/CRMAdapter/CRMAdapter.UI/Pages/Invoices/Detail.razor
@@ -50,14 +50,19 @@
                         <StatusChip Status="@_invoice.Status" Size="Size.Medium" />
                     </MudStack>
                     <MudStack Row="true" Spacing="1" Justify="Justify.FlexEnd" Wrap="true">
-                        <MudButton Variant="Variant.Filled"
-                                   Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.Payments"
-                                   Disabled="@(_invoice.BalanceDue <= 0)"
-                                   OnClick="OpenPaymentDialogAsync"
-                                   data-testid="record-payment-button">
-                            Record payment
-                        </MudButton>
+                        <AuditActionInvoker Action="Invoice.RecordPayment"
+                                             EntityId="@(_invoice?.Id.ToString())"
+                                             OnExecute="EventCallback.Factory.Create(this, OpenPaymentDialogAsync)">
+                            @((EventCallback callback) =>
+                                <MudButton Variant="Variant.Filled"
+                                           Color="Color.Primary"
+                                           StartIcon="@Icons.Material.Filled.Payments"
+                                           Disabled="@(_invoice.BalanceDue <= 0)"
+                                           OnClick="callback"
+                                           data-testid="record-payment-button">
+                                    Record payment
+                                </MudButton>)
+                        </AuditActionInvoker>
                         <MudButton Variant="Variant.Outlined" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.MarkEmailRead" Disabled="true">
                             Send email
                         </MudButton>

--- a/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationContext.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationContext.cs
@@ -6,17 +6,68 @@ namespace CRMAdapter.UI.Services.Diagnostics;
 
 public sealed class CorrelationContext
 {
+    /// <summary>
+    /// Header name used to propagate correlation identifiers between the UI and API layers.
+    /// </summary>
+    public const string HeaderName = "X-Correlation-ID";
+
+    private readonly object _syncRoot = new();
     private string _currentCorrelationId = CreateCorrelationId();
 
-    public string CurrentCorrelationId => _currentCorrelationId;
+    /// <summary>
+    /// Gets the current correlation identifier for outbound operations.
+    /// </summary>
+    public string CurrentCorrelationId
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _currentCorrelationId;
+            }
+        }
+    }
 
-    public string ShortCorrelationId => _currentCorrelationId.Length > 12
-        ? _currentCorrelationId[..12].ToUpperInvariant()
-        : _currentCorrelationId.ToUpperInvariant();
+    /// <summary>
+    /// Gets a shortened version of the current correlation identifier for display purposes.
+    /// </summary>
+    public string ShortCorrelationId
+    {
+        get
+        {
+            var current = CurrentCorrelationId;
+            return current.Length > 12
+                ? current[..12].ToUpperInvariant()
+                : current.ToUpperInvariant();
+        }
+    }
 
+    /// <summary>
+    /// Generates a fresh correlation identifier.
+    /// </summary>
     public void Refresh()
     {
-        _currentCorrelationId = CreateCorrelationId();
+        lock (_syncRoot)
+        {
+            _currentCorrelationId = CreateCorrelationId();
+        }
+    }
+
+    /// <summary>
+    /// Overrides the current correlation identifier if a trusted upstream value is supplied.
+    /// </summary>
+    /// <param name="correlationId">Correlation identifier provided by the API layer.</param>
+    public void SetCorrelationId(string? correlationId)
+    {
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            return;
+        }
+
+        lock (_syncRoot)
+        {
+            _currentCorrelationId = correlationId.Trim();
+        }
     }
 
     private static string CreateCorrelationId()

--- a/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationDelegatingHandler.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/Diagnostics/CorrelationDelegatingHandler.cs
@@ -1,0 +1,53 @@
+// CorrelationDelegatingHandler.cs: Ensures correlation identifiers flow between UI HTTP calls and API responses.
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.UI.Services.Diagnostics;
+
+/// <summary>
+/// Adds correlation headers to outbound API requests and updates the local context from responses.
+/// </summary>
+public sealed class CorrelationDelegatingHandler : DelegatingHandler
+{
+    private readonly CorrelationContext _correlationContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CorrelationDelegatingHandler"/> class.
+    /// </summary>
+    /// <param name="correlationContext">Context tracking the current UI correlation identifier.</param>
+    public CorrelationDelegatingHandler(CorrelationContext correlationContext)
+    {
+        _correlationContext = correlationContext ?? throw new ArgumentNullException(nameof(correlationContext));
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Headers.Remove(CorrelationContext.HeaderName);
+        request.Headers.TryAddWithoutValidation(CorrelationContext.HeaderName, _correlationContext.CurrentCorrelationId);
+
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.Headers.TryGetValues(CorrelationContext.HeaderName, out var values))
+        {
+            var headerValue = values.FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(headerValue))
+            {
+                _correlationContext.SetCorrelationId(headerValue);
+            }
+        }
+        else if (request.Headers.TryGetValues(CorrelationContext.HeaderName, out var outbound))
+        {
+            var headerValue = outbound.FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(headerValue))
+            {
+                _correlationContext.SetCorrelationId(headerValue);
+            }
+        }
+
+        return response;
+    }
+}

--- a/CRMAdapter/CRMAdapter.UI/_Imports.razor
+++ b/CRMAdapter/CRMAdapter.UI/_Imports.razor
@@ -23,6 +23,7 @@
 @using CRMAdapter.UI.Components.Appointments
 @using CRMAdapter.UI.Services.Invoices.Models
 @using CRMAdapter.UI.Components.Invoices
+@using CRMAdapter.UI.Components.Audit
 @using CRMAdapter.UI.Services.Vehicles.Models
 @using CRMAdapter.UI.Components.Vehicles
 @using CRMAdapter.UI.Services.Dashboard.Models

--- a/CRMAdapter/CommonConfig/AuditSettings.json
+++ b/CRMAdapter/CommonConfig/AuditSettings.json
@@ -1,0 +1,15 @@
+{
+  "Audit": {
+    "Sink": "File",
+    "File": {
+      "FilePath": "logs/audit.log"
+    },
+    "Sql": {
+      "ConnectionString": "Server=localhost;Database=Audit;Trusted_Connection=True;Encrypt=False;",
+      "TableName": "AuditEvents"
+    },
+    "Console": {
+      "UseConsoleColors": true
+    }
+  }
+}

--- a/CRMAdapter/CommonSecurity/AuditLogger.cs
+++ b/CRMAdapter/CommonSecurity/AuditLogger.cs
@@ -1,0 +1,271 @@
+// AuditLogger.cs: Centralized coordinator that emits structured audit events to configured sinks.
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Emits normalized audit events to the configured sinks while enforcing compliance requirements.
+/// </summary>
+public sealed class AuditLogger
+{
+    private readonly IReadOnlyCollection<IAuditSink> _sinks;
+    private readonly ILogger<AuditLogger> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuditLogger"/> class.
+    /// </summary>
+    /// <param name="sinks">Collection of audit sinks registered for the current host.</param>
+    /// <param name="logger">Logger used to report sink failures.</param>
+    public AuditLogger(IEnumerable<IAuditSink> sinks, ILogger<AuditLogger> logger)
+    {
+        if (sinks is null)
+        {
+            throw new ArgumentNullException(nameof(sinks));
+        }
+
+        _sinks = new ReadOnlyCollection<IAuditSink>(sinks.ToArray());
+        if (_sinks.Count == 0)
+        {
+            throw new InvalidOperationException("At least one audit sink must be registered.");
+        }
+
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Persists a structured audit event to every configured sink.
+    /// </summary>
+    /// <param name="auditEvent">Event payload to persist.</param>
+    /// <param name="cancellationToken">Token used to cancel downstream writes.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task LogAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        if (auditEvent is null)
+        {
+            throw new ArgumentNullException(nameof(auditEvent));
+        }
+
+        var normalized = Normalize(auditEvent);
+
+        foreach (var sink in _sinks)
+        {
+            try
+            {
+                await sink.WriteAsync(normalized, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Audit sink {Sink} failed for action {Action} with correlation {CorrelationId}.", sink.GetType().Name, normalized.Action, normalized.CorrelationId);
+            }
+        }
+    }
+
+    private static AuditEvent Normalize(AuditEvent auditEvent)
+    {
+        var timestamp = auditEvent.Timestamp == default
+            ? DateTimeOffset.UtcNow
+            : auditEvent.Timestamp.ToUniversalTime();
+
+        var correlationId = string.IsNullOrWhiteSpace(auditEvent.CorrelationId)
+            ? Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)
+            : auditEvent.CorrelationId.Trim();
+
+        var userId = MaskIfSensitive(auditEvent.UserId);
+        var role = string.IsNullOrWhiteSpace(auditEvent.Role)
+            ? "unknown"
+            : auditEvent.Role.Trim();
+
+        var metadata = auditEvent.Metadata is null
+            ? new ReadOnlyDictionary<string, string>(new Dictionary<string, string>())
+            : new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(auditEvent.Metadata));
+
+        return auditEvent with
+        {
+            Timestamp = timestamp,
+            CorrelationId = correlationId,
+            UserId = userId,
+            Role = role,
+            Metadata = metadata,
+        };
+    }
+
+    private static string MaskIfSensitive(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "anonymous";
+        }
+
+        // Redact everything but the final four characters to avoid exposing PII.
+        var trimmed = value.Trim();
+        if (trimmed.Length <= 4)
+        {
+            return new string('*', trimmed.Length);
+        }
+
+        var visibleTail = trimmed[^4..];
+        return string.Concat(new string('*', trimmed.Length - 4), visibleTail);
+    }
+}
+
+/// <summary>
+/// Structured representation of a single security-relevant action.
+/// </summary>
+/// <param name="CorrelationId">Identifier used to correlate activity across services.</param>
+/// <param name="UserId">Masked identifier for the initiating principal.</param>
+/// <param name="Role">Role or profile assigned to the principal.</param>
+/// <param name="Action">Business action performed by the user.</param>
+/// <param name="EntityId">Identifier of the entity being acted upon, if any.</param>
+/// <param name="Timestamp">UTC timestamp captured at the time of the event.</param>
+/// <param name="Result">Outcome of the attempted action.</param>
+/// <param name="Metadata">Optional supplementary, non-sensitive metadata.</param>
+public sealed record AuditEvent(
+    string CorrelationId,
+    string UserId,
+    string Role,
+    string Action,
+    string? EntityId,
+    DateTimeOffset Timestamp,
+    AuditResult Result,
+    IReadOnlyDictionary<string, string>? Metadata = null)
+{
+    /// <summary>
+    /// Serializes the event to canonical JSON representation.
+    /// </summary>
+    public string ToJson(JsonSerializerOptions? options = null)
+    {
+        options ??= DefaultSerializerOptions.Value;
+        return JsonSerializer.Serialize(this, options);
+    }
+
+    private static readonly Lazy<JsonSerializerOptions> DefaultSerializerOptions = new(() =>
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false,
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    });
+}
+
+/// <summary>
+/// Canonical set of outcomes supported by the audit log schema.
+/// </summary>
+public enum AuditResult
+{
+    /// <summary>
+    /// The action completed successfully.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The action failed due to a handled or unhandled error.
+    /// </summary>
+    Failure,
+
+    /// <summary>
+    /// The action was denied by policy enforcement.
+    /// </summary>
+    Denied,
+}
+
+/// <summary>
+/// Configuration describing the audit sink to be used by the current process.
+/// </summary>
+public sealed class AuditSettings
+{
+    /// <summary>
+    /// Name of the configuration section containing audit settings.
+    /// </summary>
+    public const string SectionName = "Audit";
+
+    /// <summary>
+    /// Gets or sets the sink identifier to activate.
+    /// </summary>
+    public string Sink { get; set; } = AuditSinkNames.Console;
+
+    /// <summary>
+    /// Gets or sets configuration applicable to the file sink.
+    /// </summary>
+    public FileSinkSettings File { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets configuration applicable to the SQL sink.
+    /// </summary>
+    public SqlSinkSettings Sql { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets configuration applicable to the console sink.
+    /// </summary>
+    public ConsoleSinkSettings Console { get; set; } = new();
+
+    /// <summary>
+    /// Strongly typed settings for the file audit sink.
+    /// </summary>
+    public sealed class FileSinkSettings
+    {
+        /// <summary>
+        /// Gets or sets the absolute or relative path to the audit log file.
+        /// </summary>
+        public string FilePath { get; set; } = "logs/audit.log";
+    }
+
+    /// <summary>
+    /// Strongly typed settings for the SQL audit sink.
+    /// </summary>
+    public sealed class SqlSinkSettings
+    {
+        /// <summary>
+        /// Gets or sets the connection string used to reach the audit database.
+        /// </summary>
+        public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fully qualified table name used to store audit events.
+        /// </summary>
+        public string TableName { get; set; } = "AuditEvents";
+    }
+
+    /// <summary>
+    /// Strongly typed settings for the console audit sink.
+    /// </summary>
+    public sealed class ConsoleSinkSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to emit ANSI color codes.
+        /// </summary>
+        public bool UseConsoleColors { get; set; } = false;
+    }
+}
+
+/// <summary>
+/// Known sink identifiers used to select concrete implementations.
+/// </summary>
+public static class AuditSinkNames
+{
+    /// <summary>
+    /// File-based audit sink identifier.
+    /// </summary>
+    public const string File = "File";
+
+    /// <summary>
+    /// SQL-based audit sink identifier.
+    /// </summary>
+    public const string Sql = "Sql";
+
+    /// <summary>
+    /// Console-based audit sink identifier.
+    /// </summary>
+    public const string Console = "Console";
+}

--- a/CRMAdapter/CommonSecurity/AuditServiceCollectionExtensions.cs
+++ b/CRMAdapter/CommonSecurity/AuditServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+// AuditServiceCollectionExtensions.cs: Dependency injection helpers for audit logging infrastructure.
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Extension methods for wiring audit logging components into DI containers.
+/// </summary>
+public static class AuditServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="AuditLogger"/> and configured sink using application configuration.
+    /// </summary>
+    /// <param name="services">Service collection to configure.</param>
+    /// <param name="configuration">Configuration root used to resolve <see cref="AuditSettings"/>.</param>
+    /// <returns>The supplied service collection for chaining.</returns>
+    public static IServiceCollection AddAuditLogging(this IServiceCollection services, IConfiguration configuration)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        services.Configure<AuditSettings>(configuration.GetSection(AuditSettings.SectionName));
+        services.AddSingleton<AuditLogger>();
+
+        services.AddSingleton<IAuditSink>(provider =>
+        {
+            var options = provider.GetRequiredService<IOptions<AuditSettings>>();
+            var settings = options.Value ?? new AuditSettings();
+            var sinkName = settings.Sink?.Trim();
+            return sinkName?.Equals(AuditSinkNames.File, StringComparison.OrdinalIgnoreCase) == true
+                ? provider.GetRequiredService<FileAuditSink>()
+                : sinkName?.Equals(AuditSinkNames.Sql, StringComparison.OrdinalIgnoreCase) == true
+                    ? provider.GetRequiredService<SqlAuditSink>()
+                    : provider.GetRequiredService<ConsoleAuditSink>();
+        });
+
+        services.AddSingleton<FileAuditSink>();
+        services.AddSingleton<SqlAuditSink>();
+        services.AddSingleton<ConsoleAuditSink>();
+
+        return services;
+    }
+}

--- a/CRMAdapter/CommonSecurity/ConsoleAuditSink.cs
+++ b/CRMAdapter/CommonSecurity/ConsoleAuditSink.cs
@@ -1,0 +1,57 @@
+// ConsoleAuditSink.cs: Emits audit events to the console for development diagnostics.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Writes audit events to STDOUT using structured JSON payloads.
+/// </summary>
+public sealed class ConsoleAuditSink : IAuditSink
+{
+    private readonly bool _useColors;
+    private readonly ILogger<ConsoleAuditSink> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsoleAuditSink"/> class.
+    /// </summary>
+    public ConsoleAuditSink(IOptions<AuditSettings> settingsAccessor, ILogger<ConsoleAuditSink> logger)
+    {
+        if (settingsAccessor is null)
+        {
+            throw new ArgumentNullException(nameof(settingsAccessor));
+        }
+
+        _useColors = settingsAccessor.Value?.Console.UseConsoleColors ?? false;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task WriteAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var payload = auditEvent.ToJson();
+            if (_useColors)
+            {
+                var original = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.Out.WriteLine(payload);
+                Console.ForegroundColor = original;
+            }
+            else
+            {
+                Console.Out.WriteLine(payload);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write audit event to console.");
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/CRMAdapter/CommonSecurity/FileAuditSink.cs
+++ b/CRMAdapter/CommonSecurity/FileAuditSink.cs
@@ -1,0 +1,60 @@
+// FileAuditSink.cs: Persists audit events to a JSON lines file for local inspection.
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Writes audit entries to an append-only JSON log on the local filesystem.
+/// </summary>
+public sealed class FileAuditSink : IAuditSink
+{
+    private readonly string _filePath;
+    private readonly ILogger<FileAuditSink> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileAuditSink"/> class.
+    /// </summary>
+    /// <param name="settingsAccessor">Accessor for audit configuration.</param>
+    /// <param name="logger">Logger used to report file write failures.</param>
+    public FileAuditSink(IOptions<AuditSettings> settingsAccessor, ILogger<FileAuditSink> logger)
+    {
+        if (settingsAccessor is null)
+        {
+            throw new ArgumentNullException(nameof(settingsAccessor));
+        }
+
+        var settings = settingsAccessor.Value ?? throw new InvalidOperationException("Audit settings must be configured.");
+        if (string.IsNullOrWhiteSpace(settings.File.FilePath))
+        {
+            throw new InvalidOperationException("Audit file path must be provided when using the file sink.");
+        }
+
+        _filePath = settings.File.FilePath;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(_filePath));
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var payload = auditEvent.ToJson() + Environment.NewLine;
+            await File.AppendAllTextAsync(_filePath, payload, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to append audit event to {AuditFile}.", _filePath);
+        }
+    }
+}

--- a/CRMAdapter/CommonSecurity/IAuditSink.cs
+++ b/CRMAdapter/CommonSecurity/IAuditSink.cs
@@ -1,0 +1,19 @@
+// IAuditSink.cs: Abstraction for persisting structured audit events to various backends.
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Represents a durable destination for audit events emitted by the platform.
+/// </summary>
+public interface IAuditSink
+{
+    /// <summary>
+    /// Persists the supplied audit event to the underlying storage medium.
+    /// </summary>
+    /// <param name="auditEvent">Structured event to persist.</param>
+    /// <param name="cancellationToken">Token used to cancel the write operation.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
+    Task WriteAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default);
+}

--- a/CRMAdapter/CommonSecurity/SqlAuditSink.cs
+++ b/CRMAdapter/CommonSecurity/SqlAuditSink.cs
@@ -1,0 +1,70 @@
+// SqlAuditSink.cs: Persists audit events to a relational database table using parameterized commands.
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Writes audit events to a SQL table for tamper-evident retention.
+/// </summary>
+public sealed class SqlAuditSink : IAuditSink
+{
+    private readonly string? _connectionString;
+    private readonly string _tableName;
+    private readonly ILogger<SqlAuditSink> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlAuditSink"/> class.
+    /// </summary>
+    public SqlAuditSink(IOptions<AuditSettings> settingsAccessor, ILogger<SqlAuditSink> logger)
+    {
+        if (settingsAccessor is null)
+        {
+            throw new ArgumentNullException(nameof(settingsAccessor));
+        }
+
+        var settings = settingsAccessor.Value ?? throw new InvalidOperationException("Audit settings must be configured.");
+        _connectionString = settings.Sql.ConnectionString;
+        _tableName = string.IsNullOrWhiteSpace(settings.Sql.TableName) ? "AuditEvents" : settings.Sql.TableName;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_connectionString))
+        {
+            _logger.LogWarning("SQL audit sink is configured without a connection string. Event will be dropped.");
+            return;
+        }
+
+        try
+        {
+            await using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandType = CommandType.Text;
+            command.CommandText = $"INSERT INTO {_tableName} (CorrelationId, UserId, Role, Action, EntityId, TimestampUtc, Result, Payload) " +
+                                  "VALUES (@CorrelationId, @UserId, @Role, @Action, @EntityId, @TimestampUtc, @Result, @Payload);";
+            command.Parameters.AddWithValue("@CorrelationId", auditEvent.CorrelationId);
+            command.Parameters.AddWithValue("@UserId", auditEvent.UserId);
+            command.Parameters.AddWithValue("@Role", auditEvent.Role);
+            command.Parameters.AddWithValue("@Action", auditEvent.Action);
+            command.Parameters.AddWithValue("@EntityId", auditEvent.EntityId ?? (object)DBNull.Value);
+            command.Parameters.AddWithValue("@TimestampUtc", auditEvent.Timestamp.UtcDateTime);
+            command.Parameters.AddWithValue("@Result", auditEvent.Result.ToString());
+            command.Parameters.AddWithValue("@Payload", auditEvent.ToJson());
+
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist audit event to SQL table {AuditTable}.", _tableName);
+        }
+    }
+}

--- a/CRMAdapter/Tests/AuditTests/ApiAuditMiddlewareTests.cs
+++ b/CRMAdapter/Tests/AuditTests/ApiAuditMiddlewareTests.cs
@@ -1,0 +1,43 @@
+// ApiAuditMiddlewareTests.cs: Integration-style tests covering API audit middleware outcomes.
+using System;
+using System.Threading.Tasks;
+using CRMAdapter.Api.Middleware;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CRMAdapter.Tests.AuditTests;
+
+public sealed class ApiAuditMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_WhenAuthorizationDenies_ShouldLogDeniedResult()
+    {
+        // Arrange
+        var sink = new TestAuditSink();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Debug));
+        var auditLogger = new AuditLogger(new[] { sink }, loggerFactory.CreateLogger<AuditLogger>());
+        var middleware = new AuditMiddleware(
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return Task.CompletedTask;
+            },
+            auditLogger,
+            loggerFactory.CreateLogger<AuditMiddleware>());
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.TraceIdentifier = Guid.NewGuid().ToString("N");
+        httpContext.Request.Method = HttpMethods.Get;
+        httpContext.Request.Path = "/customers";
+        httpContext.Request.RouteValues["id"] = Guid.NewGuid();
+
+        // Act
+        await middleware.InvokeAsync(httpContext);
+
+        // Assert
+        sink.Events.Should().Contain(e => e.Action == "Customer.View" && e.Result == AuditResult.Denied);
+    }
+}

--- a/CRMAdapter/Tests/AuditTests/AuditLoggerTests.cs
+++ b/CRMAdapter/Tests/AuditTests/AuditLoggerTests.cs
@@ -1,0 +1,71 @@
+// AuditLoggerTests.cs: Unit tests covering normalization and fail-open behavior of the audit logger.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CRMAdapter.Tests.AuditTests;
+
+public sealed class AuditLoggerTests
+{
+    [Fact]
+    public async Task LogAsync_ShouldNormalizeFieldsBeforeForwarding()
+    {
+        // Arrange
+        var sink = new TestAuditSink();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Debug));
+        var auditLogger = new AuditLogger(new[] { sink }, loggerFactory.CreateLogger<AuditLogger>());
+
+        var input = new AuditEvent(
+            CorrelationId: string.Empty,
+            UserId: "alice@example.com",
+            Role: " Sales ",
+            Action: "Customer.View",
+            EntityId: "12345",
+            Timestamp: default,
+            Result: AuditResult.Success,
+            Metadata: new Dictionary<string, string> { ["client"] = "ui" });
+
+        // Act
+        await auditLogger.LogAsync(input);
+
+        // Assert
+        sink.Events.Should().HaveCount(1);
+        var recorded = sink.Events.Single();
+        recorded.CorrelationId.Should().NotBeNullOrWhiteSpace();
+        recorded.CorrelationId.Should().NotBe(input.CorrelationId);
+        recorded.UserId.Should().EndWith(".com");
+        recorded.UserId.Should().NotContain("alice", StringComparison.OrdinalIgnoreCase);
+        recorded.Role.Should().Be("Sales");
+        recorded.Timestamp.Offset.Should().Be(TimeSpan.Zero);
+        recorded.Metadata.Should().ContainKey("client");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldContinueWhenSinkThrows()
+    {
+        // Arrange
+        var failingSink = new ThrowingAuditSink();
+        var capturingSink = new TestAuditSink();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddFilter(_ => true));
+        var auditLogger = new AuditLogger(new IAuditSink[] { failingSink, capturingSink }, loggerFactory.CreateLogger<AuditLogger>());
+
+        // Act
+        await auditLogger.LogAsync(new AuditEvent("corr", "user", "role", "Action", null, DateTimeOffset.UtcNow, AuditResult.Success));
+
+        // Assert
+        capturingSink.Events.Should().HaveCount(1);
+    }
+
+    private sealed class ThrowingAuditSink : IAuditSink
+    {
+        public Task WriteAsync(AuditEvent auditEvent, System.Threading.CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("boom");
+        }
+    }
+}

--- a/CRMAdapter/Tests/AuditTests/TestAuditSink.cs
+++ b/CRMAdapter/Tests/AuditTests/TestAuditSink.cs
@@ -1,0 +1,21 @@
+// TestAuditSink.cs: Lightweight in-memory audit sink used for verification scenarios.
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+
+namespace CRMAdapter.Tests.AuditTests;
+
+internal sealed class TestAuditSink : IAuditSink
+{
+    private readonly ConcurrentQueue<AuditEvent> _events = new();
+
+    public IReadOnlyCollection<AuditEvent> Events => _events.ToArray();
+
+    public Task WriteAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        _events.Enqueue(auditEvent);
+        return Task.CompletedTask;
+    }
+}

--- a/CRMAdapter/Tests/AuditTests/UiAuditFlowTests.cs
+++ b/CRMAdapter/Tests/AuditTests/UiAuditFlowTests.cs
@@ -1,0 +1,149 @@
+// UiAuditFlowTests.cs: End-to-end style validation of UI to API audit event propagation.
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Bunit;
+using CRMAdapter.Api.Middleware;
+using CRMAdapter.CommonSecurity;
+using CRMAdapter.UI.Components.Audit;
+using CRMAdapter.UI.Services.Diagnostics;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CRMAdapter.Tests.AuditTests;
+
+public sealed class UiAuditFlowTests : IDisposable
+{
+    private readonly TestContext _testContext;
+    private readonly TestAuditSink _sink;
+
+    public UiAuditFlowTests()
+    {
+        _testContext = new TestContext();
+        _sink = new TestAuditSink();
+
+        _testContext.Services.AddLogging();
+        _testContext.Services.AddSingleton(_sink);
+        _testContext.Services.AddSingleton<IAuditSink>(_sink);
+        _testContext.Services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<AuditLogger>>();
+            var sinks = new[] { sp.GetRequiredService<IAuditSink>() };
+            return new AuditLogger(sinks, logger);
+        });
+        _testContext.Services.AddSingleton(new CorrelationContext());
+        _testContext.Services.AddSingleton<AuthenticationStateProvider>(new StaticAuthStateProvider());
+    }
+
+    [Fact]
+    public async Task ClickingAuditedAction_ShouldEmitUiAndApiEventsWithSharedCorrelation()
+    {
+        // Arrange
+        var correlationContext = _testContext.Services.GetRequiredService<CorrelationContext>();
+        correlationContext.SetCorrelationId(Guid.NewGuid().ToString("N"));
+        var auditLogger = _testContext.Services.GetRequiredService<AuditLogger>();
+        var middleware = new AuditMiddleware(
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                return Task.CompletedTask;
+            },
+            auditLogger,
+            NullLogger<AuditMiddleware>.Instance);
+
+        var entityId = Guid.NewGuid().ToString("N");
+
+        var component = _testContext.RenderComponent<AuditActionInvoker>(parameters => parameters
+            .Add(p => p.Action, "Invoice.Export")
+            .Add(p => p.EntityId, entityId)
+            .Add(p => p.OnExecute, EventCallback.Factory.Create(this, async () =>
+            {
+                var httpContext = new DefaultHttpContext
+                {
+                    TraceIdentifier = correlationContext.CurrentCorrelationId,
+                };
+                httpContext.Items[CorrelationIdMiddleware.CorrelationHeaderName] = correlationContext.CurrentCorrelationId;
+                httpContext.Request.Method = HttpMethods.Post;
+                httpContext.Request.Path = "/invoices/export";
+                httpContext.Request.RouteValues["invoiceId"] = entityId;
+                httpContext.Response.StatusCode = StatusCodes.Status200OK;
+                await middleware.InvokeAsync(httpContext);
+            }))
+            .Add(p => p.ChildContent, callback => builder =>
+            {
+                builder.OpenElement(0, "button");
+                builder.AddAttribute(1, "type", "button");
+                builder.AddAttribute(2, "onclick", callback);
+                builder.AddContent(3, "Export");
+                builder.CloseElement();
+            }));
+
+        // Act
+        await component.Find("button").ClickAsync();
+
+        // Assert
+        var events = _sink.Events;
+        events.Should().Contain(e => e.Action == "Invoice.Export.Attempt" && e.Metadata is { } meta && meta.TryGetValue("origin", out var origin) && origin == "UI");
+        events.Should().Contain(e => e.Action == "Invoice.Export" && e.Metadata is { } meta && meta.TryGetValue("origin", out var origin) && origin == "UI" && e.Result == AuditResult.Success);
+        events.Should().Contain(e => e.Action == "Invoice.Export.Attempt" && e.Metadata is { } meta && meta.TryGetValue("origin", out var origin) && origin == "API");
+        events.Should().Contain(e => e.Action == "Invoice.Export" && e.Metadata is { } meta && meta.TryGetValue("origin", out var origin) && origin == "API");
+        events.Select(e => e.CorrelationId).Distinct().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ClickingAuditedAction_WhenCallbackThrows_ShouldLogFailure()
+    {
+        // Arrange
+        var correlationContext = _testContext.Services.GetRequiredService<CorrelationContext>();
+        correlationContext.SetCorrelationId(Guid.NewGuid().ToString("N"));
+
+        var component = _testContext.RenderComponent<AuditActionInvoker>(parameters => parameters
+            .Add(p => p.Action, "Invoice.Download")
+            .Add(p => p.EntityId, Guid.NewGuid().ToString("N"))
+            .Add(p => p.OnExecute, EventCallback.Factory.Create(this, async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("Simulated failure");
+            }))
+            .Add(p => p.ChildContent, callback => builder =>
+            {
+                builder.OpenElement(0, "button");
+                builder.AddAttribute(1, "type", "button");
+                builder.AddAttribute(2, "onclick", callback);
+                builder.AddContent(3, "Download");
+                builder.CloseElement();
+            }));
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await component.Find("button").ClickAsync());
+
+        // Assert
+        _sink.Events.Should().Contain(e => e.Action == "Invoice.Download" && e.Result == AuditResult.Failure && e.Metadata is { } meta && meta.TryGetValue("origin", out var origin) && origin == "UI");
+    }
+
+    public void Dispose()
+    {
+        _testContext.Dispose();
+    }
+
+    private sealed class StaticAuthStateProvider : AuthenticationStateProvider
+    {
+        private readonly ClaimsPrincipal _principal = new(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "user-12345"),
+            new Claim(ClaimTypes.Role, "Finance"),
+        }, authenticationType: "test"));
+
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+        {
+            return Task.FromResult(new AuthenticationState(_principal));
+        }
+    }
+}

--- a/CRMAdapter/Tests/CRMAdapter.Tests.csproj
+++ b/CRMAdapter/Tests/CRMAdapter.Tests.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="../CRMAdapter.Core/CRMAdapter.Core.csproj" />
     <ProjectReference Include="../CRMAdapter.Api/CRMAdapter.Api.csproj" />
     <ProjectReference Include="../CommonSecurity/CommonSecurity.csproj" />
+    <ProjectReference Include="../CRMAdapter.UI/CRMAdapter.UI.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +26,7 @@
     <Compile Include="ChaosTests/**/*.cs" />
     <Compile Include="TestUtilities/**/*.cs" />
     <Compile Include="RbacTests/**/*.cs" />
+    <Compile Include="AuditTests/**/*.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,6 +47,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="bunit" Version="1.30.1" />
     <PackageReference Include="Polly" Version="8.4.0" />
     <PackageReference Include="Polly.Contrib.Simmy" Version="0.3.0" />
     <PackageReference Include="Respawn" Version="6.2.1" />


### PR DESCRIPTION
## Summary
- add reusable audit logger, sinks, and configuration helpers shared across API and UI
- instrument API pipeline with audit middleware and wrap UI actions with an audit invoker component
- introduce correlation-aware HTTP handler and comprehensive audit tests covering success, failure, and denial scenarios

## Testing
- `dotnet test CRMAdapter/CRMAdapter.sln` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d484f9e62c832fac252b264f407214