### PR TITLE
Implement secrets management and encryption framework

### DIFF
--- a/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
+++ b/CRMAdapter/CRMAdapter.Api/Config/appsettings.json
@@ -9,15 +9,10 @@
       "LogName": "Application"
     },
     "ApplicationInsights": {
-      "ConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/",
       "RoleName": "crm-adapter-api"
     }
   },
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "VastDesktop": "Server=localhost;Database=VastDesktop;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=False;",
-    "VastOnline": "Server=localhost;Database=VastOnline;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=False;"
-  },
   "CRM": {
     "Backend": "VAST_DESKTOP",
     "Mapping": {

--- a/CRMAdapter/CRMAdapter.Api/Middleware/SecurityGuardMiddleware.cs
+++ b/CRMAdapter/CRMAdapter.Api/Middleware/SecurityGuardMiddleware.cs
@@ -1,0 +1,51 @@
+// SecurityGuardMiddleware.cs: Blocks requests if critical secrets are unavailable.
+using System;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.Api.Middleware;
+
+public sealed class SecurityGuardMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ResolvedSecrets _resolvedSecrets;
+    private readonly ILogger<SecurityGuardMiddleware> _logger;
+
+    public SecurityGuardMiddleware(RequestDelegate next, ResolvedSecrets resolvedSecrets, ILogger<SecurityGuardMiddleware> logger)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _resolvedSecrets = resolvedSecrets ?? throw new ArgumentNullException(nameof(resolvedSecrets));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (!_resolvedSecrets.IsHealthy)
+        {
+            var correlationId = context.Items.TryGetValue(CorrelationIdMiddleware.CorrelationHeaderName, out var value) ? value?.ToString() : string.Empty;
+            _logger.LogError("Critical secrets unavailable. Rejecting request with correlation {CorrelationId}.", correlationId);
+
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.ContentType = "application/problem+json";
+            var problem = new ProblemDetails
+            {
+                Status = StatusCodes.Status503ServiceUnavailable,
+                Title = "Service unavailable",
+                Detail = "Critical secrets are unavailable. Please retry once the service recovers.",
+            };
+            problem.Extensions["correlationId"] = correlationId;
+            await context.Response.WriteAsJsonAsync(problem).ConfigureAwait(false);
+            return;
+        }
+
+        await _next(context).ConfigureAwait(false);
+    }
+}

--- a/CRMAdapter/CRMAdapter.Api/Program.cs
+++ b/CRMAdapter/CRMAdapter.Api/Program.cs
@@ -2,14 +2,28 @@
 // Summary: Entry point for the CRMAdapter.Api application that wires up the minimal API pipeline.
 using System.IO;
 using CRMAdapter.Api.Logging;
+using CRMAdapter.CommonSecurity;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var commonConfigPath = Path.Combine(builder.Environment.ContentRootPath, "..", "CommonConfig");
+builder.Configuration.AddJsonFile(Path.Combine(commonConfigPath, "AuditSettings.json"), optional: true, reloadOnChange: true);
+builder.Configuration.AddJsonFile(Path.Combine(commonConfigPath, "SecuritySettings.json"), optional: false, reloadOnChange: false);
 builder.Configuration.AddJsonFile(Path.Combine(builder.Environment.ContentRootPath, "Config", "AuditSettings.json"), optional: true, reloadOnChange: true);
+
+using var bootstrapLoggerFactory = LoggerFactory.Create(logging => logging.AddConsole());
+var securityBootstrap = await SecurityBootstrapper.InitializeAsync(builder.Configuration, builder.Environment, bootstrapLoggerFactory);
+
+builder.Services.AddSingleton(securityBootstrap.Settings);
+builder.Services.AddSingleton(securityBootstrap.Secrets);
+builder.Services.AddSingleton<ISecretsProvider>(_ => securityBootstrap.Provider);
+builder.Services.AddSingleton<DataProtector>();
+builder.Services.AddSingleton<SecretsResolver>();
 
 SerilogConfig.Configure(builder);
 
-var startup = new CRMAdapter.Api.Startup(builder.Configuration, builder.Environment);
+var startup = new CRMAdapter.Api.Startup(builder.Configuration, builder.Environment, securityBootstrap.Secrets);
 startup.ConfigureServices(builder.Services);
 
 var app = builder.Build();

--- a/CRMAdapter/CRMAdapter.UI/Services/EncryptedStorageService.cs
+++ b/CRMAdapter/CRMAdapter.UI/Services/EncryptedStorageService.cs
@@ -1,0 +1,83 @@
+// EncryptedStorageService.cs: Wraps protected browser storage with AES-GCM encryption.
+using System;
+using System.Security;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using CRMAdapter.UI.Services.Diagnostics;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.UI.Services;
+
+public sealed class EncryptedStorageService
+{
+    private readonly ProtectedSessionStorage _sessionStorage;
+    private readonly DataProtector _dataProtector;
+    private readonly CorrelationContext _correlationContext;
+    private readonly ILogger<EncryptedStorageService> _logger;
+
+    public EncryptedStorageService(
+        ProtectedSessionStorage sessionStorage,
+        DataProtector dataProtector,
+        CorrelationContext correlationContext,
+        ILogger<EncryptedStorageService> logger)
+    {
+        _sessionStorage = sessionStorage ?? throw new ArgumentNullException(nameof(sessionStorage));
+        _dataProtector = dataProtector ?? throw new ArgumentNullException(nameof(dataProtector));
+        _correlationContext = correlationContext ?? throw new ArgumentNullException(nameof(correlationContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task SetAsync(string key, string value)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        var correlationId = _correlationContext.CurrentCorrelationId;
+        var encrypted = _dataProtector.Encrypt(value, correlationId);
+        await _sessionStorage.SetAsync(key, encrypted).AsTask().ConfigureAwait(false);
+    }
+
+    public async Task<string?> GetAsync(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        var stored = await _sessionStorage.GetAsync<string>(key).ConfigureAwait(false);
+        if (!stored.Success || string.IsNullOrWhiteSpace(stored.Value))
+        {
+            return null;
+        }
+
+        var correlationId = _correlationContext.CurrentCorrelationId;
+        try
+        {
+            return _dataProtector.Decrypt(stored.Value!, correlationId);
+        }
+        catch (SecurityException ex)
+        {
+            _logger.LogWarning(ex, "Failed to decrypt stored value for key {Key} and correlation {CorrelationId}.", key, correlationId);
+            await _sessionStorage.DeleteAsync(key).AsTask().ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    public Task DeleteAsync(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        return _sessionStorage.DeleteAsync(key).AsTask();
+    }
+}

--- a/CRMAdapter/CommonConfig/AuditSettings.json
+++ b/CRMAdapter/CommonConfig/AuditSettings.json
@@ -5,7 +5,7 @@
       "FilePath": "logs/audit.log"
     },
     "Sql": {
-      "ConnectionString": "Server=localhost;Database=Audit;Trusted_Connection=True;Encrypt=False;",
+      "ConnectionString": "",
       "TableName": "AuditEvents"
     },
     "Console": {

--- a/CRMAdapter/CommonConfig/SecuritySettings.json
+++ b/CRMAdapter/CommonConfig/SecuritySettings.json
@@ -1,0 +1,22 @@
+{
+  "Security": {
+    "UseKeyVault": false,
+    "VaultProvider": "Azure",
+    "VaultUrl": "",
+    "EncryptionKeyId": "CRM_ENCRYPTION_KEY_CURRENT",
+    "PreviousEncryptionKeyIds": [],
+    "Secrets": {
+      "JwtSigningKey": "CRM_JWT_SIGNING_KEY",
+      "Sql": {
+        "VastDesktop": "CRM_SQL_VAST_DESKTOP",
+        "VastOnline": "CRM_SQL_VAST_ONLINE",
+        "Audit": "CRM_SQL_AUDIT"
+      },
+      "Api": {
+        "ClientId": "CRM_API_CLIENT_ID",
+        "ClientSecret": "CRM_API_CLIENT_SECRET"
+      }
+    },
+    "AwsRegion": ""
+  }
+}

--- a/CRMAdapter/CommonSecurity/CommonSecurity.csproj
+++ b/CRMAdapter/CommonSecurity/CommonSecurity.csproj
@@ -5,4 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.303.3" />
+  </ItemGroup>
 </Project>

--- a/CRMAdapter/CommonSecurity/DataProtector.cs
+++ b/CRMAdapter/CommonSecurity/DataProtector.cs
@@ -1,0 +1,136 @@
+// DataProtector.cs: Provides AES-256-GCM encryption utilities for sensitive data.
+using System;
+using System.Security;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Encrypts and decrypts sensitive payloads using AES-256-GCM with key rotation support.
+/// </summary>
+public sealed class DataProtector
+{
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+
+    private readonly SecuritySettings _settings;
+    private readonly ResolvedSecrets _resolvedSecrets;
+    private readonly ILogger<DataProtector> _logger;
+
+    public DataProtector(SecuritySettings settings, ResolvedSecrets resolvedSecrets, ILogger<DataProtector> logger)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _resolvedSecrets = resolvedSecrets ?? throw new ArgumentNullException(nameof(resolvedSecrets));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Encrypts plaintext using the active encryption key.
+    /// </summary>
+    public string Encrypt(string plaintext, string correlationId)
+    {
+        if (plaintext is null)
+        {
+            throw new ArgumentNullException(nameof(plaintext));
+        }
+
+        var keyId = _settings.EncryptionKeyId;
+        if (!_resolvedSecrets.EncryptionKeys.TryGetValue(keyId, out var keyBytes))
+        {
+            throw new SecurityException($"Encryption key '{keyId}' is not available.");
+        }
+
+        var nonce = new byte[NonceSize];
+        RandomNumberGenerator.Fill(nonce);
+
+        var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+        var cipherBytes = new byte[plaintextBytes.Length];
+        var tag = new byte[TagSize];
+
+        try
+        {
+            using var aes = new AesGcm(keyBytes);
+            aes.Encrypt(nonce, plaintextBytes, cipherBytes, tag);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new SecurityException($"Encryption failure for correlation {correlationId}.", ex);
+        }
+
+        var payload = new byte[nonce.Length + cipherBytes.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, payload, 0, nonce.Length);
+        Buffer.BlockCopy(cipherBytes, 0, payload, nonce.Length, cipherBytes.Length);
+        Buffer.BlockCopy(tag, 0, payload, nonce.Length + cipherBytes.Length, tag.Length);
+
+        var envelope = string.Concat(keyId, ":", Convert.ToBase64String(payload));
+        _logger.LogDebug("Encrypted payload using key {KeyId} for correlation {CorrelationId}.", keyId, correlationId);
+        return envelope;
+    }
+
+    /// <summary>
+    /// Decrypts a payload previously encrypted by <see cref="Encrypt"/>.
+    /// </summary>
+    public string Decrypt(string encryptedPayload, string correlationId)
+    {
+        if (string.IsNullOrWhiteSpace(encryptedPayload))
+        {
+            throw new ArgumentNullException(nameof(encryptedPayload));
+        }
+
+        var separatorIndex = encryptedPayload.IndexOf(':');
+        if (separatorIndex <= 0)
+        {
+            throw new SecurityException($"Encrypted payload is missing key metadata for correlation {correlationId}.");
+        }
+
+        var keyId = encryptedPayload[..separatorIndex];
+        var encoded = encryptedPayload[(separatorIndex + 1)..];
+
+        if (!_resolvedSecrets.EncryptionKeys.TryGetValue(keyId, out var keyBytes))
+        {
+            _logger.LogWarning("Encrypted payload referenced unknown key {KeyId} for correlation {CorrelationId}.", keyId, correlationId);
+            throw new SecurityException($"Unknown encryption key '{keyId}'.");
+        }
+
+        byte[] payloadBytes;
+        try
+        {
+            payloadBytes = Convert.FromBase64String(encoded);
+        }
+        catch (FormatException ex)
+        {
+            throw new SecurityException($"Encrypted payload is not valid base64 for correlation {correlationId}.", ex);
+        }
+
+        if (payloadBytes.Length < NonceSize + TagSize)
+        {
+            throw new SecurityException($"Encrypted payload is truncated for correlation {correlationId}.");
+        }
+
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipherLength = payloadBytes.Length - NonceSize - TagSize;
+        var cipherBytes = new byte[cipherLength];
+
+        Buffer.BlockCopy(payloadBytes, 0, nonce, 0, NonceSize);
+        Buffer.BlockCopy(payloadBytes, NonceSize, cipherBytes, 0, cipherLength);
+        Buffer.BlockCopy(payloadBytes, NonceSize + cipherLength, tag, 0, TagSize);
+
+        var plaintextBytes = new byte[cipherLength];
+
+        try
+        {
+            using var aes = new AesGcm(keyBytes);
+            aes.Decrypt(nonce, cipherBytes, tag, plaintextBytes);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new SecurityException($"Decryption failure for correlation {correlationId}.", ex);
+        }
+
+        _logger.LogDebug("Decrypted payload using key {KeyId} for correlation {CorrelationId}.", keyId, correlationId);
+        return Encoding.UTF8.GetString(plaintextBytes);
+    }
+}

--- a/CRMAdapter/CommonSecurity/EnvSecretsProvider.cs
+++ b/CRMAdapter/CommonSecurity/EnvSecretsProvider.cs
@@ -1,0 +1,71 @@
+// EnvSecretsProvider.cs: Resolves secrets from environment variables for development and CI.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Retrieves secrets from environment variables.
+/// </summary>
+public sealed class EnvSecretsProvider : ISecretsProvider
+{
+    private readonly ILogger<EnvSecretsProvider> _logger;
+    private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public EnvSecretsProvider(ILogger<EnvSecretsProvider> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        if (_cache.TryGetValue(name, out var cached))
+        {
+            return Task.FromResult<string?>(cached);
+        }
+
+        var value = Environment.GetEnvironmentVariable(name);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _cache[name] = value;
+            _logger.LogInformation("Environment secret {SecretName} resolved.", name);
+        }
+        else
+        {
+            _logger.LogWarning("Environment secret {SecretName} not found.", name);
+        }
+
+        return Task.FromResult<string?>(value);
+    }
+
+    /// <inheritdoc />
+    public async Task<IDictionary<string, string>> GetSecretsAsync(IEnumerable<string> names, CancellationToken cancellationToken = default)
+    {
+        if (names is null)
+        {
+            throw new ArgumentNullException(nameof(names));
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in names)
+        {
+            var value = await GetSecretAsync(name, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                result[name] = value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/CRMAdapter/CommonSecurity/ISecretsProvider.cs
+++ b/CRMAdapter/CommonSecurity/ISecretsProvider.cs
@@ -1,0 +1,22 @@
+// ISecretsProvider.cs: Abstraction for retrieving secret material from different backends.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Represents a provider capable of retrieving secret values by logical name.
+/// </summary>
+public interface ISecretsProvider
+{
+    /// <summary>
+    /// Retrieves the value of a single secret name.
+    /// </summary>
+    Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves multiple secret values in bulk.
+    /// </summary>
+    Task<IDictionary<string, string>> GetSecretsAsync(IEnumerable<string> names, CancellationToken cancellationToken = default);
+}

--- a/CRMAdapter/CommonSecurity/Properties/AssemblyInfo.cs
+++ b/CRMAdapter/CommonSecurity/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CRMAdapter.Tests")]

--- a/CRMAdapter/CommonSecurity/ResolvedSecrets.cs
+++ b/CRMAdapter/CommonSecurity/ResolvedSecrets.cs
@@ -1,0 +1,52 @@
+// ResolvedSecrets.cs: Immutable snapshot of secret material resolved during startup.
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Represents the resolved secrets required by the application at runtime.
+/// </summary>
+public sealed class ResolvedSecrets
+{
+    public ResolvedSecrets(
+        string jwtSigningKey,
+        IReadOnlyDictionary<string, string> sqlConnections,
+        IReadOnlyDictionary<string, string> apiCredentials,
+        IReadOnlyDictionary<string, byte[]> encryptionKeys)
+    {
+        JwtSigningKey = jwtSigningKey ?? throw new ArgumentNullException(nameof(jwtSigningKey));
+        SqlConnections = new ReadOnlyDictionary<string, string>(sqlConnections ?? throw new ArgumentNullException(nameof(sqlConnections)));
+        ApiCredentials = new ReadOnlyDictionary<string, string>(apiCredentials ?? throw new ArgumentNullException(nameof(apiCredentials)));
+        EncryptionKeys = new ReadOnlyDictionary<string, byte[]>(encryptionKeys ?? throw new ArgumentNullException(nameof(encryptionKeys)));
+    }
+
+    /// <summary>
+    /// Gets the symmetric key used to validate inbound JWT tokens.
+    /// </summary>
+    public string JwtSigningKey { get; }
+
+    /// <summary>
+    /// Gets the SQL connection strings indexed by logical backend name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> SqlConnections { get; }
+
+    /// <summary>
+    /// Gets API credential material indexed by logical name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ApiCredentials { get; }
+
+    /// <summary>
+    /// Gets the encryption keys indexed by key identifier.
+    /// </summary>
+    public IReadOnlyDictionary<string, byte[]> EncryptionKeys { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether all critical secrets have been resolved.
+    /// </summary>
+    public bool IsHealthy => !string.IsNullOrWhiteSpace(JwtSigningKey)
+        && SqlConnections.TryGetValue("VastDesktop", out var desktop) && !string.IsNullOrWhiteSpace(desktop)
+        && SqlConnections.TryGetValue("VastOnline", out var online) && !string.IsNullOrWhiteSpace(online)
+        && EncryptionKeys.Count > 0;
+}

--- a/CRMAdapter/CommonSecurity/SecretsResolver.cs
+++ b/CRMAdapter/CommonSecurity/SecretsResolver.cs
@@ -1,0 +1,135 @@
+// SecretsResolver.cs: Coordinates retrieval of secrets from the configured provider.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Helper responsible for fetching all required secrets and transforming them into a strongly typed model.
+/// </summary>
+public sealed class SecretsResolver
+{
+    private readonly ISecretsProvider _secretsProvider;
+    private readonly ILogger<SecretsResolver> _logger;
+
+    public SecretsResolver(ISecretsProvider secretsProvider, ILogger<SecretsResolver> logger)
+    {
+        _secretsProvider = secretsProvider ?? throw new ArgumentNullException(nameof(secretsProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Resolves the secret material required by the host.
+    /// </summary>
+    public async Task<ResolvedSecrets> ResolveAsync(SecuritySettings settings, CancellationToken cancellationToken = default)
+    {
+        if (settings is null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        settings.Validate();
+
+        var sqlSecretNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["VastDesktop"] = settings.Secrets.Sql.VastDesktop,
+            ["VastOnline"] = settings.Secrets.Sql.VastOnline,
+            ["Audit"] = settings.Secrets.Sql.Audit,
+        };
+
+        var apiSecretNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ClientId"] = settings.Secrets.Api.ClientId,
+            ["ClientSecret"] = settings.Secrets.Api.ClientSecret,
+        };
+
+        var requiredSecretNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            settings.Secrets.JwtSigningKey,
+            settings.EncryptionKeyId,
+        };
+
+        foreach (var name in sqlSecretNames.Values.Concat(settings.PreviousEncryptionKeyIds))
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                requiredSecretNames.Add(name);
+            }
+        }
+
+        var optionalSecretNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in apiSecretNames.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                optionalSecretNames.Add(name);
+            }
+        }
+
+        var requestedSecretNames = new HashSet<string>(requiredSecretNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in optionalSecretNames)
+        {
+            requestedSecretNames.Add(name);
+        }
+
+        var secretDictionary = await _secretsProvider.GetSecretsAsync(requestedSecretNames, cancellationToken).ConfigureAwait(false);
+
+        var missingSecrets = requiredSecretNames
+            .Where(name => !secretDictionary.ContainsKey(name) || string.IsNullOrWhiteSpace(secretDictionary[name]))
+            .ToArray();
+
+        if (missingSecrets.Length > 0)
+        {
+            var scrubbed = string.Join(", ", missingSecrets.Select(name => name));
+            throw new SecurityException($"Missing required secrets: {scrubbed}.");
+        }
+
+        var sqlConnections = sqlSecretNames.ToDictionary(
+            kvp => kvp.Key,
+            kvp => secretDictionary[kvp.Value],
+            StringComparer.OrdinalIgnoreCase);
+
+        var apiCredentials = apiSecretNames
+            .Where(kvp => secretDictionary.TryGetValue(kvp.Value, out var value) && !string.IsNullOrWhiteSpace(value))
+            .ToDictionary(kvp => kvp.Key, kvp => secretDictionary[kvp.Value], StringComparer.OrdinalIgnoreCase);
+
+        var encryptionKeys = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        var activeKey = secretDictionary[settings.EncryptionKeyId];
+        encryptionKeys[settings.EncryptionKeyId] = DecodeKey(settings.EncryptionKeyId, activeKey);
+
+        foreach (var legacyKey in settings.PreviousEncryptionKeyIds)
+        {
+            if (secretDictionary.TryGetValue(legacyKey, out var legacyValue) && !string.IsNullOrWhiteSpace(legacyValue))
+            {
+                encryptionKeys[legacyKey] = DecodeKey(legacyKey, legacyValue);
+            }
+        }
+
+        var resolved = new ResolvedSecrets(
+            jwtSigningKey: secretDictionary[settings.Secrets.JwtSigningKey],
+            sqlConnections: sqlConnections,
+            apiCredentials: apiCredentials,
+            encryptionKeys: encryptionKeys);
+
+        _logger.LogInformation("Secrets resolved successfully for {SqlConnectionCount} SQL targets and {EncryptionKeyCount} encryption keys.", sqlConnections.Count, encryptionKeys.Count);
+
+        return resolved;
+    }
+
+    private static byte[] DecodeKey(string keyId, string encodedValue)
+    {
+        try
+        {
+            return Convert.FromBase64String(encodedValue);
+        }
+        catch (FormatException ex)
+        {
+            throw new SecurityException(FormattableString.Invariant($"Encryption key '{keyId}' is not a valid base64 string."), ex);
+        }
+    }
+}

--- a/CRMAdapter/CommonSecurity/SecurityBootstrapper.cs
+++ b/CRMAdapter/CommonSecurity/SecurityBootstrapper.cs
@@ -1,0 +1,56 @@
+// SecurityBootstrapper.cs: Shared helper to wire security services across hosts.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Provides a consistent bootstrap flow for loading secrets and registering encryption services.
+/// </summary>
+public static class SecurityBootstrapper
+{
+    public static async Task<SecurityBootstrapContext> InitializeAsync(
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        if (environment is null)
+        {
+            throw new ArgumentNullException(nameof(environment));
+        }
+
+        if (loggerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        var settings = new SecuritySettings();
+        configuration.GetSection(SecuritySettings.SectionName).Bind(settings);
+        settings.Validate();
+
+        var providerLogger = loggerFactory.CreateLogger<VaultSecretsProvider>();
+        ISecretsProvider provider = settings.UseKeyVault
+            ? new VaultSecretsProvider(settings, providerLogger)
+            : new EnvSecretsProvider(loggerFactory.CreateLogger<EnvSecretsProvider>());
+
+        var resolver = new SecretsResolver(provider, loggerFactory.CreateLogger<SecretsResolver>());
+        var resolvedSecrets = await resolver.ResolveAsync(settings, cancellationToken).ConfigureAwait(false);
+
+        return new SecurityBootstrapContext(settings, provider, resolvedSecrets);
+    }
+}
+
+/// <summary>
+/// Represents the result of the security bootstrap process.
+/// </summary>
+public sealed record SecurityBootstrapContext(SecuritySettings Settings, ISecretsProvider Provider, ResolvedSecrets Secrets);

--- a/CRMAdapter/CommonSecurity/SecuritySettings.cs
+++ b/CRMAdapter/CommonSecurity/SecuritySettings.cs
@@ -1,0 +1,154 @@
+// SecuritySettings.cs: Configuration binding model describing how secrets are stored and retrieved.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Configuration describing how secrets should be resolved for the current host.
+/// </summary>
+public sealed class SecuritySettings
+{
+    /// <summary>
+    /// Configuration section name used within configuration files.
+    /// </summary>
+    public const string SectionName = "Security";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a remote vault should be used for secret retrieval.
+    /// </summary>
+    public bool UseKeyVault { get; set; }
+
+    /// <summary>
+    /// Gets or sets the vault provider identifier ("Azure" or "Aws").
+    /// </summary>
+    public string VaultProvider { get; set; } = "Azure";
+
+    /// <summary>
+    /// Gets or sets the vault endpoint URL when using Azure Key Vault.
+    /// </summary>
+    public string? VaultUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the AWS region identifier when targeting Secrets Manager.
+    /// </summary>
+    public string? AwsRegion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the secret identifier that contains the active encryption key.
+    /// </summary>
+    public string EncryptionKeyId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the identifiers for previous encryption keys that remain valid for decryption only.
+    /// </summary>
+    public IList<string> PreviousEncryptionKeyIds { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the logical secret names used throughout the application.
+    /// </summary>
+    public SecretNameSettings Secrets { get; set; } = new();
+
+    /// <summary>
+    /// Validates the configuration and throws if required values are missing.
+    /// </summary>
+    public void Validate()
+    {
+        if (Secrets is null)
+        {
+            throw new InvalidOperationException("Security.Secrets configuration is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Secrets.JwtSigningKey))
+        {
+            throw new InvalidOperationException("Security.Secrets.JwtSigningKey must be configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Secrets.Sql.VastDesktop)
+            || string.IsNullOrWhiteSpace(Secrets.Sql.VastOnline)
+            || string.IsNullOrWhiteSpace(Secrets.Sql.Audit))
+        {
+            throw new InvalidOperationException("Security.Secrets.Sql secret names must be configured for VastDesktop, VastOnline, and Audit.");
+        }
+
+        if (UseKeyVault)
+        {
+            if (string.Equals(VaultProvider, "Azure", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(VaultUrl))
+                {
+                    throw new InvalidOperationException("Security.VaultUrl must be supplied when UseKeyVault is enabled for Azure.");
+                }
+            }
+            else if (string.Equals(VaultProvider, "Aws", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(AwsRegion))
+                {
+                    throw new InvalidOperationException("Security.AwsRegion must be supplied when UseKeyVault targets AWS Secrets Manager.");
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"Security.VaultProvider '{VaultProvider}' is not supported. Expected 'Azure' or 'Aws'.");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(EncryptionKeyId))
+        {
+            throw new InvalidOperationException("Security.EncryptionKeyId must be provided.");
+        }
+
+        if (PreviousEncryptionKeyIds is null)
+        {
+            PreviousEncryptionKeyIds = new List<string>();
+        }
+        else
+        {
+            PreviousEncryptionKeyIds = PreviousEncryptionKeyIds.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+}
+
+/// <summary>
+/// Logical secret names used by the application.
+/// </summary>
+public sealed class SecretNameSettings
+{
+    /// <summary>
+    /// Gets or sets the JWT signing key secret name.
+    /// </summary>
+    public string JwtSigningKey { get; set; } = "CRM_JWT_SIGNING_KEY";
+
+    /// <summary>
+    /// Gets or sets the SQL secret names.
+    /// </summary>
+    public SqlSecretNames Sql { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets API credential secret names.
+    /// </summary>
+    public ApiSecretNames Api { get; set; } = new();
+}
+
+/// <summary>
+/// Secret name manifest for SQL connection strings.
+/// </summary>
+public sealed class SqlSecretNames
+{
+    public string VastDesktop { get; set; } = "CRM_SQL_VAST_DESKTOP";
+
+    public string VastOnline { get; set; } = "CRM_SQL_VAST_ONLINE";
+
+    public string Audit { get; set; } = "CRM_SQL_AUDIT";
+}
+
+/// <summary>
+/// Secret name manifest for downstream API credentials.
+/// </summary>
+public sealed class ApiSecretNames
+{
+    public string ClientId { get; set; } = "CRM_API_CLIENT_ID";
+
+    public string ClientSecret { get; set; } = "CRM_API_CLIENT_SECRET";
+}

--- a/CRMAdapter/CommonSecurity/VaultSecretsProvider.cs
+++ b/CRMAdapter/CommonSecurity/VaultSecretsProvider.cs
@@ -1,0 +1,185 @@
+// VaultSecretsProvider.cs: Resolves secrets from Azure Key Vault or AWS Secrets Manager.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Logging;
+
+namespace CRMAdapter.CommonSecurity;
+
+/// <summary>
+/// Retrieves secret material from a cloud-hosted vault.
+/// </summary>
+public sealed class VaultSecretsProvider : ISecretsProvider
+{
+    private readonly IVaultAdapter _adapter;
+    private readonly ILogger<VaultSecretsProvider> _logger;
+    private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public VaultSecretsProvider(SecuritySettings settings, ILogger<VaultSecretsProvider> logger)
+        : this(CreateAdapter(settings), logger)
+    {
+    }
+
+    internal VaultSecretsProvider(IVaultAdapter adapter, ILogger<VaultSecretsProvider> logger)
+    {
+        _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        if (_cache.TryGetValue(name, out var cached))
+        {
+            return cached;
+        }
+
+        var value = await _adapter.GetSecretAsync(name, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _cache[name] = value;
+            _logger.LogInformation("Vault secret {SecretName} resolved.", name);
+        }
+        else
+        {
+            _logger.LogWarning("Vault secret {SecretName} not found.", name);
+        }
+
+        return value;
+    }
+
+    /// <inheritdoc />
+    public async Task<IDictionary<string, string>> GetSecretsAsync(IEnumerable<string> names, CancellationToken cancellationToken = default)
+    {
+        if (names is null)
+        {
+            throw new ArgumentNullException(nameof(names));
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in names)
+        {
+            var value = await GetSecretAsync(name, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                result[name] = value;
+            }
+        }
+
+        return result;
+    }
+
+    private static IVaultAdapter CreateAdapter(SecuritySettings settings)
+    {
+        if (settings is null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        settings.Validate();
+
+        if (string.Equals(settings.VaultProvider, "Azure", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(settings.VaultUrl))
+            {
+                throw new InvalidOperationException("VaultUrl must be provided for Azure Key Vault.");
+            }
+
+            var vaultUri = new Uri(settings.VaultUrl, UriKind.Absolute);
+            var credential = new DefaultAzureCredential();
+            var client = new SecretClient(vaultUri, credential);
+            return new AzureKeyVaultAdapter(client);
+        }
+
+        if (string.Equals(settings.VaultProvider, "Aws", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(settings.AwsRegion))
+            {
+                throw new InvalidOperationException("AwsRegion must be provided for AWS Secrets Manager.");
+            }
+
+            var regionEndpoint = RegionEndpoint.GetBySystemName(settings.AwsRegion);
+            var client = new AmazonSecretsManagerClient(regionEndpoint);
+            return new AwsSecretsManagerAdapter(client);
+        }
+
+        throw new InvalidOperationException($"Unsupported vault provider '{settings.VaultProvider}'.");
+    }
+}
+
+internal interface IVaultAdapter
+{
+    Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken);
+}
+
+internal sealed class AzureKeyVaultAdapter : IVaultAdapter
+{
+    private readonly SecretClient _client;
+
+    public AzureKeyVaultAdapter(SecretClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public async Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _client.GetSecretAsync(name, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return response.Value?.Value;
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+}
+
+internal sealed class AwsSecretsManagerAdapter : IVaultAdapter
+{
+    private readonly IAmazonSecretsManager _client;
+
+    public AwsSecretsManagerAdapter(IAmazonSecretsManager client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public async Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _client.GetSecretValueAsync(new GetSecretValueRequest
+            {
+                SecretId = name,
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(response.SecretString))
+            {
+                return response.SecretString;
+            }
+
+            if (response.SecretBinary is not null)
+            {
+                return System.Text.Encoding.UTF8.GetString(response.SecretBinary.ToArray());
+            }
+
+            return null;
+        }
+        catch (ResourceNotFoundException)
+        {
+            return null;
+        }
+    }
+}

--- a/CRMAdapter/Tests/SecurityTests/DataProtectorTests.cs
+++ b/CRMAdapter/Tests/SecurityTests/DataProtectorTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CRMAdapter.Tests.SecurityTests;
+
+public sealed class DataProtectorTests
+{
+    [Fact]
+    public void EncryptDecrypt_RoundTrips()
+    {
+        var keyId = "TEST_KEY";
+        var securitySettings = new SecuritySettings
+        {
+            EncryptionKeyId = keyId,
+            Secrets = new SecretNameSettings
+            {
+                JwtSigningKey = "JWT_KEY",
+                Sql = new SqlSecretNames { VastDesktop = "SQL_DESKTOP", VastOnline = "SQL_ONLINE", Audit = "SQL_AUDIT" },
+            },
+        };
+
+        var keyBytes = RandomNumberGenerator.GetBytes(32);
+        var secrets = new ResolvedSecrets(
+            jwtSigningKey: "jwt-secret",
+            sqlConnections: new Dictionary<string, string> { ["VastDesktop"] = "Server=.;", ["VastOnline"] = "Server=.;", ["Audit"] = "Server=.;" },
+            apiCredentials: new Dictionary<string, string>(),
+            encryptionKeys: new Dictionary<string, byte[]> { [keyId] = keyBytes });
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+        var protector = new DataProtector(securitySettings, secrets, loggerFactory.CreateLogger<DataProtector>());
+
+        const string plaintext = "Highly Sensitive Token";
+        var correlation = Guid.NewGuid().ToString();
+
+        var encrypted = protector.Encrypt(plaintext, correlation);
+        encrypted.Should().NotBeNullOrWhiteSpace();
+
+        var roundTrip = protector.Decrypt(encrypted, correlation);
+        roundTrip.Should().Be(plaintext);
+    }
+}

--- a/CRMAdapter/Tests/SecurityTests/SecretsProviderTests.cs
+++ b/CRMAdapter/Tests/SecurityTests/SecretsProviderTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CRMAdapter.Tests.SecurityTests;
+
+public sealed class SecretsProviderTests
+{
+    [Fact]
+    public async Task EnvSecretsProvider_ResolvesConfiguredValues()
+    {
+        const string secretName = "UNIT_TEST_SECRET";
+        Environment.SetEnvironmentVariable(secretName, "super-secret-value");
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+        var provider = new EnvSecretsProvider(loggerFactory.CreateLogger<EnvSecretsProvider>());
+
+        try
+        {
+            var resolved = await provider.GetSecretAsync(secretName);
+            resolved.Should().Be("super-secret-value");
+
+            var batch = await provider.GetSecretsAsync(new[] { secretName });
+            batch.Should().ContainKey(secretName);
+            batch[secretName].Should().Be("super-secret-value");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(secretName, null);
+        }
+    }
+
+    [Fact]
+    public async Task VaultSecretsProvider_UsesAdapter()
+    {
+        var backingStore = new Dictionary<string, string>
+        {
+            ["sample-secret"] = "value-from-vault",
+        };
+
+        var adapter = new TestVaultAdapter(backingStore);
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+        var provider = new VaultSecretsProvider(adapter, loggerFactory.CreateLogger<VaultSecretsProvider>());
+
+        var resolved = await provider.GetSecretAsync("sample-secret");
+        resolved.Should().Be("value-from-vault");
+    }
+
+    private sealed class TestVaultAdapter : IVaultAdapter
+    {
+        private readonly IDictionary<string, string> _store;
+
+        public TestVaultAdapter(IDictionary<string, string> store)
+        {
+            _store = store;
+        }
+
+        public Task<string?> GetSecretAsync(string name, CancellationToken cancellationToken)
+        {
+            _store.TryGetValue(name, out var value);
+            return Task.FromResult<string?>(value);
+        }
+    }
+}

--- a/CRMAdapter/Tests/SecurityTests/SecurityTestEnvironment.cs
+++ b/CRMAdapter/Tests/SecurityTests/SecurityTestEnvironment.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace CRMAdapter.Tests.SecurityTests;
+
+internal static class SecurityTestEnvironment
+{
+    private static bool _initialized;
+
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        SetIfMissing("CRM_JWT_SIGNING_KEY", "unit-test-signing-key");
+        SetIfMissing("CRM_SQL_VAST_DESKTOP", "Server=localhost;Database=VastDesktop;Encrypt=True;TrustServerCertificate=False;");
+        SetIfMissing("CRM_SQL_VAST_ONLINE", "Server=localhost;Database=VastOnline;Encrypt=True;TrustServerCertificate=False;");
+        SetIfMissing("CRM_SQL_AUDIT", "Server=localhost;Database=Audit;Encrypt=True;TrustServerCertificate=False;");
+        SetIfMissing("CRM_ENCRYPTION_KEY_CURRENT", Convert.ToBase64String(new byte[32]));
+        SetIfMissing("CRM_API_CLIENT_ID", "test-client-id");
+        SetIfMissing("CRM_API_CLIENT_SECRET", "test-client-secret");
+    }
+
+    private static void SetIfMissing(string name, string value)
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name)))
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+}

--- a/CRMAdapter/Tests/SecurityTests/SqlAuditSinkTests.cs
+++ b/CRMAdapter/Tests/SecurityTests/SqlAuditSinkTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CRMAdapter.Tests.SecurityTests;
+
+public sealed class SqlAuditSinkTests
+{
+    [Fact]
+    public void DecryptPayload_RestoresOriginalValue()
+    {
+        var settings = new SecuritySettings
+        {
+            EncryptionKeyId = "CRM_ENCRYPTION_KEY_CURRENT",
+            Secrets = new SecretNameSettings
+            {
+                JwtSigningKey = "CRM_JWT_SIGNING_KEY",
+                Sql = new SqlSecretNames
+                {
+                    VastDesktop = "CRM_SQL_VAST_DESKTOP",
+                    VastOnline = "CRM_SQL_VAST_ONLINE",
+                    Audit = "CRM_SQL_AUDIT",
+                },
+            },
+        };
+
+        var resolvedSecrets = new ResolvedSecrets(
+            jwtSigningKey: "jwt-secret",
+            sqlConnections: new Dictionary<string, string>
+            {
+                ["VastDesktop"] = "Server=.;Encrypt=True;",
+                ["VastOnline"] = "Server=.;Encrypt=True;",
+                ["Audit"] = "Server=.;Encrypt=True;",
+            },
+            apiCredentials: new Dictionary<string, string>(),
+            encryptionKeys: new Dictionary<string, byte[]>
+            {
+                ["CRM_ENCRYPTION_KEY_CURRENT"] = new byte[32],
+            });
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+        var protector = new DataProtector(settings, resolvedSecrets, loggerFactory.CreateLogger<DataProtector>());
+        var options = Options.Create(new AuditSettings
+        {
+            Sql = new AuditSettings.SqlSinkSettings
+            {
+                ConnectionString = "Server=.;Encrypt=True;",
+            },
+        });
+
+        var sink = new SqlAuditSink(options, resolvedSecrets, protector, loggerFactory.CreateLogger<SqlAuditSink>());
+        var correlationId = Guid.NewGuid().ToString();
+        var encrypted = protector.Encrypt("payload", correlationId);
+        var decrypted = sink.DecryptPayload(encrypted, correlationId);
+
+        decrypted.Should().Be("payload");
+    }
+}

--- a/CRMAdapter/Tests/SecurityTests/StartupGuardTests.cs
+++ b/CRMAdapter/Tests/SecurityTests/StartupGuardTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using CRMAdapter.CommonSecurity;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CRMAdapter.Tests.SecurityTests;
+
+public sealed class StartupGuardTests
+{
+    [Fact]
+    public async Task Bootstrap_Fails_WhenSigningKeyMissing()
+    {
+        var encryptionKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+        Environment.SetEnvironmentVariable("CRM_SQL_VAST_DESKTOP", "Server=.;Encrypt=True;TrustServerCertificate=False;");
+        Environment.SetEnvironmentVariable("CRM_SQL_VAST_ONLINE", "Server=.;Encrypt=True;TrustServerCertificate=False;");
+        Environment.SetEnvironmentVariable("CRM_SQL_AUDIT", "Server=.;Encrypt=True;TrustServerCertificate=False;");
+        Environment.SetEnvironmentVariable("CRM_ENCRYPTION_KEY_CURRENT", encryptionKey);
+        Environment.SetEnvironmentVariable("CRM_JWT_SIGNING_KEY", null);
+
+        try
+        {
+            var configValues = new Dictionary<string, string?>
+            {
+                ["Security:UseKeyVault"] = "false",
+                ["Security:EncryptionKeyId"] = "CRM_ENCRYPTION_KEY_CURRENT",
+                ["Security:Secrets:JwtSigningKey"] = "CRM_JWT_SIGNING_KEY",
+                ["Security:Secrets:Sql:VastDesktop"] = "CRM_SQL_VAST_DESKTOP",
+                ["Security:Secrets:Sql:VastOnline"] = "CRM_SQL_VAST_ONLINE",
+                ["Security:Secrets:Sql:Audit"] = "CRM_SQL_AUDIT",
+                ["Security:Secrets:Api:ClientId"] = "CRM_API_CLIENT_ID",
+                ["Security:Secrets:Api:ClientSecret"] = "CRM_API_CLIENT_SECRET",
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+            var environment = new TestHostEnvironment();
+
+            Func<Task> act = () => SecurityBootstrapper.InitializeAsync(configuration, environment, loggerFactory);
+
+            await act.Should().ThrowAsync<System.Security.SecurityException>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CRM_SQL_VAST_DESKTOP", null);
+            Environment.SetEnvironmentVariable("CRM_SQL_VAST_ONLINE", null);
+            Environment.SetEnvironmentVariable("CRM_SQL_AUDIT", null);
+            Environment.SetEnvironmentVariable("CRM_ENCRYPTION_KEY_CURRENT", null);
+            Environment.SetEnvironmentVariable("CRM_JWT_SIGNING_KEY", null);
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "CRMAdapter.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce SecuritySettings configuration, pluggable secret providers, and an AES-GCM DataProtector with key rotation support shared across services
- bootstrap CRMAdapter.Api and CRMAdapter.UI with centralized secrets loading, enforce TLS-protected SQL connections, add security guard middleware, and encrypt cached tokens via a new EncryptedStorageService
- add regression tests covering data protection, secret provider resolution, startup failures without secrets, and SQL payload encryption

## Testing
- `dotnet test` *(fails: dotnet CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48a7af45c832f880fdf813336c6bc